### PR TITLE
Do not copy state from props on subsequent renders

### DIFF
--- a/examples/callback/app.js
+++ b/examples/callback/app.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Tab, Tabs, TabList, TabPanel } from '../../lib/main';
+
+const App = React.createClass({
+
+  getInitialState() {
+    return { value: 0 };
+  },
+
+  handleChange(index) {
+    this.setState({ value: index + 1 });
+    this.forceUpdate(() => {});
+  },
+
+  render() {
+    return (
+      <div>
+        <div style={{borderBottom: '1px solid #666', marginBottom: 20}}>{this.state.value}</div>
+        <div style={{padding: 50}}>
+          <Tabs onSelect={this.handleChange}>
+            <TabList>
+              <Tab>First</Tab>
+              <Tab>Second</Tab>
+              <Tab>Third</Tab>
+              <Tab>Fourth</Tab>
+            </TabList>
+            <TabPanel><p>First Content</p></TabPanel>
+            <TabPanel><p>Second content</p></TabPanel>
+            <TabPanel><p>Third content</p></TabPanel>
+            <TabPanel><p>Fourth content</p></TabPanel>
+          </Tabs>
+        </div>
+      </div>
+	);
+  }
+});
+
+ReactDOM.render(<App/>, document.getElementById('example'));

--- a/examples/callback/index.html
+++ b/examples/callback/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset="utf-8"/>
+<title>React Tabs</title>
+<body>
+	<div id="example"></div>
+	<script src="../__build__/shared.js"></script>
+	<script src="../__build__/callback.js"></script>


### PR DESCRIPTION
We were running into a problem with tabs and redux, which made tabs not clickable.
This example illustrates the behavior

```javascript
class App extends Component {
  handleSelect() {
    this.forceUpdate(() => {})
  }
  render() {
    <Tabs onSelected={this.handleSelect}>
      ...
    </Tabs>
  }
}
```

So when we click on a tab:
What happens is that before the Tabs-Component calls the onSelected-handler it calls its `setState()` with the new `selectedIndex`. Then in the onSelected-handler we are somehow triggering a rerender (in our case a redux-action, but can also be `forceUpdate()`). Now the Tabs-Component receives newProps and calls `setState()` again, which leads to state either changes to the the tab with index 0 or if newProps.selectedIndex > -1 to its value, because the first setState() was not yet applied and therfore gets "overwritten" by the second one. And the result is, that the tab can not be changed.

The fix is to either only update the state when the props changed or remove the `componentWillReceiveProps()` method at all. 
I decided for removing it, as also the README says that the props are only used for the first render not for subsequent ones.
Why is the componentWillReceiveProps() there at all currently?