### PR TITLE
Update karma version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "devDependencies": {
     "react": "^0.11.0",
     "jsx-loader": "^0.10.2",
-    "karma": "^0.12.17",
-	"karma-cli": "0.0.4",
+    "karma": "^0.13.0",
+	  "karma-cli": "0.0.4",
     "karma-jasmine": "^0.1.5",
     "karma-chrome-launcher": "^0.1.4",
     "karma-firefox-launcher": "^0.1.3",


### PR DESCRIPTION
karma version was causing build to fail. It was giving following error :

WARN [preprocess]: Can not load "webpack"!
  TypeError: Object [object Object] has no method 'refreshFiles'

This issue was fixed in version 0.13.

[ https://github.com/webpack/karma-webpack/issues/68](https://github.com/webpack/karma-webpack/issues/68)