### PR TITLE
Remove aria-expanded attribute

### DIFF
--- a/lib/components/Tab.js
+++ b/lib/components/Tab.js
@@ -62,7 +62,6 @@ module.exports = React.createClass({
         role="tab"
         id={this.props.id}
         aria-selected={this.props.selected ? 'true' : 'false'}
-        aria-expanded={this.props.selected ? 'true' : 'false'}
         aria-disabled={this.props.disabled ? 'true' : 'false'}
         aria-controls={this.props.panelId}
       >

--- a/lib/components/__tests__/Tab-test.js
+++ b/lib/components/__tests__/Tab-test.js
@@ -13,7 +13,6 @@ describe('Tab', function() {
     equal(node.className, 'ReactTabs__Tab');
     equal(node.getAttribute('role'), 'tab');
     equal(node.getAttribute('aria-selected'), 'false');
-    equal(node.getAttribute('aria-expanded'), 'false');
     equal(node.getAttribute('aria-disabled'), 'false');
     equal(node.getAttribute('aria-controls'), null);
     equal(node.getAttribute('id'), null);
@@ -33,7 +32,6 @@ describe('Tab', function() {
 
     equal(node.className, 'ReactTabs__Tab ReactTabs__Tab--selected');
     equal(node.getAttribute('aria-selected'), 'true');
-    equal(node.getAttribute('aria-expanded'), 'true');
     equal(node.getAttribute('aria-controls'), '1234');
     equal(node.getAttribute('id'), 'abcd');
     equal(node.innerHTML, 'Hello');


### PR DESCRIPTION
The aria-expanded attribute is redundant here, as the natural state of a selected tab is expanded.  It also causes the Jaws screen reader to read each tab, as it is arrowed to, strangely.