### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "5"
+  - "4"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-dom": "^0.14.7"
   },
   "devDependencies": {
-    "rackt-cli": "^0.5.4",
+    "rackt-cli": "mzabriskie/rackt-cli",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-modal": "rackt/react-modal",


### PR DESCRIPTION
Changing the Node version to `4` in `.travis.yml` and referring to the `master` branch on GitHub for the `rackt-cli` package in `package.json` fixes the build. This is because:
* `rackt-cli` needs npm v2.x to work, and Node 4 ships with that version (but isn't ancient like 0.10, which was used before @timdorr tried to get this package up to date), and
* a PR was recently merged over at `rackt-cli` that fixed a different (much smaller) issue by updating a dependency, but this hasn't been pushed to npm yet

Obviously this won't actually fix the tests breaking locally if you're using Node 5.x, but at least we'll be able to look at a green badge again :). If this gets merged, other PRs will need to be rebased onto `master`, after which we'll once again be able to easily see which PRs are genuinely breaking tests and which are ready for review.

It seems @mzabriskie is super busy with other stuff atm so hopefully someone else from the reactjs org can help us out here. @timdorr perhaps?