### PR TITLE
Server side rendering checksum error fix.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": ["react", "es2015", "stage-0"],
+  "ignore": ["*.css"]
+}
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - "5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "5"

--- a/dist/components/Tab.js
+++ b/dist/components/Tab.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require('react-dom');
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function syncNodeAttributes(node, props) {
+  if (props.selected) {
+    node.setAttribute('tabindex', 0);
+    node.setAttribute('selected', 'selected');
+    if (props.focus) {
+      node.focus();
+    }
+  } else {
+    node.removeAttribute('tabindex');
+    node.removeAttribute('selected');
+  }
+}
+
+module.exports = _react2.default.createClass({
+  displayName: 'Tab',
+
+  propTypes: {
+    className: _react.PropTypes.string,
+    id: _react.PropTypes.string,
+    selected: _react.PropTypes.bool,
+    disabled: _react.PropTypes.bool,
+    panelId: _react.PropTypes.string,
+    children: _react.PropTypes.oneOfType([_react.PropTypes.array, _react.PropTypes.object, _react.PropTypes.string])
+  },
+
+  getDefaultProps: function getDefaultProps() {
+    return {
+      focus: false,
+      selected: false,
+      id: null,
+      panelId: null
+    };
+  },
+  componentDidMount: function componentDidMount() {
+    syncNodeAttributes((0, _reactDom.findDOMNode)(this), this.props);
+  },
+  componentDidUpdate: function componentDidUpdate() {
+    syncNodeAttributes((0, _reactDom.findDOMNode)(this), this.props);
+  },
+  render: function render() {
+    return _react2.default.createElement(
+      'li',
+      {
+        className: (0, _classnames2.default)('ReactTabs__Tab', this.props.className, {
+          'ReactTabs__Tab--selected': this.props.selected,
+          'ReactTabs__Tab--disabled': this.props.disabled
+        }),
+        role: 'tab',
+        id: this.props.id,
+        'aria-selected': this.props.selected ? 'true' : 'false',
+        'aria-expanded': this.props.selected ? 'true' : 'false',
+        'aria-disabled': this.props.disabled ? 'true' : 'false',
+        'aria-controls': this.props.panelId
+      },
+      this.props.children
+    );
+  }
+});

--- a/dist/components/TabList.js
+++ b/dist/components/TabList.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+module.exports = _react2.default.createClass({
+  displayName: 'TabList',
+
+  propTypes: {
+    className: _react.PropTypes.string,
+    children: _react.PropTypes.oneOfType([_react.PropTypes.object, _react.PropTypes.array])
+  },
+
+  render: function render() {
+    return _react2.default.createElement(
+      'ul',
+      {
+        className: (0, _classnames2.default)('ReactTabs__TabList', this.props.className),
+        role: 'tablist'
+      },
+      this.props.children
+    );
+  }
+});

--- a/dist/components/TabPanel.js
+++ b/dist/components/TabPanel.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+module.exports = _react2.default.createClass({
+  displayName: 'TabPanel',
+
+  propTypes: {
+    className: _react.PropTypes.string,
+    selected: _react.PropTypes.bool,
+    id: _react.PropTypes.string,
+    tabId: _react.PropTypes.string,
+    children: _react.PropTypes.oneOfType([_react.PropTypes.array, _react.PropTypes.object, _react.PropTypes.string])
+  },
+
+  contextTypes: {
+    forceRenderTabPanel: _react.PropTypes.bool
+  },
+
+  getDefaultProps: function getDefaultProps() {
+    return {
+      selected: false,
+      id: null,
+      tabId: null
+    };
+  },
+  render: function render() {
+    var children = this.context.forceRenderTabPanel || this.props.selected ? this.props.children : null;
+
+    return _react2.default.createElement(
+      'div',
+      {
+        className: (0, _classnames2.default)('ReactTabs__TabPanel', this.props.className, {
+          'ReactTabs__TabPanel--selected': this.props.selected
+        }),
+        role: 'tabpanel',
+        id: this.props.id,
+        'aria-labelledby': this.props.tabId,
+        style: { display: this.props.selected ? null : 'none' }
+      },
+      children
+    );
+  }
+});

--- a/dist/components/Tabs.js
+++ b/dist/components/Tabs.js
@@ -1,0 +1,340 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require('react-dom');
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
+var _jsStylesheet = require('js-stylesheet');
+
+var _jsStylesheet2 = _interopRequireDefault(_jsStylesheet);
+
+var _uuid = require('../helpers/uuid');
+
+var _uuid2 = _interopRequireDefault(_uuid);
+
+var _childrenPropType = require('../helpers/childrenPropType');
+
+var _childrenPropType2 = _interopRequireDefault(_childrenPropType);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// Determine if a node from event.target is a Tab element
+function isTabNode(node) {
+  return node.nodeName === 'LI' && node.getAttribute('role') === 'tab';
+}
+
+// Determine if a tab node is disabled
+function isTabDisabled(node) {
+  return node.getAttribute('aria-disabled') === 'true';
+}
+
+var useDefaultStyles = true;
+
+module.exports = _react2.default.createClass({
+  displayName: 'Tabs',
+
+  propTypes: {
+    className: _react.PropTypes.string,
+    selectedIndex: _react.PropTypes.number,
+    onSelect: _react.PropTypes.func,
+    focus: _react.PropTypes.bool,
+    children: _childrenPropType2.default,
+    forceRenderTabPanel: _react.PropTypes.bool,
+    tabPostfix: _react.PropTypes.string
+  },
+
+  childContextTypes: {
+    forceRenderTabPanel: _react.PropTypes.bool
+  },
+
+  statics: {
+    setUseDefaultStyles: function setUseDefaultStyles(use) {
+      useDefaultStyles = use;
+    }
+  },
+
+  getDefaultProps: function getDefaultProps() {
+    return {
+      selectedIndex: -1,
+      focus: false,
+      forceRenderTabPanel: false
+    };
+  },
+  getInitialState: function getInitialState() {
+    return this.copyPropsToState(this.props);
+  },
+  getChildContext: function getChildContext() {
+    return {
+      forceRenderTabPanel: this.props.forceRenderTabPanel
+    };
+  },
+  componentDidMount: function componentDidMount() {
+    if (useDefaultStyles) {
+      (0, _jsStylesheet2.default)(require('../helpers/styles.js'));
+    }
+  },
+  componentWillReceiveProps: function componentWillReceiveProps(newProps) {
+    this.setState(this.copyPropsToState(newProps));
+  },
+  handleClick: function handleClick(e) {
+    var node = e.target;
+    do {
+      if (isTabNode(node)) {
+        if (isTabDisabled(node)) {
+          return;
+        }
+
+        var index = [].slice.call(node.parentNode.children).indexOf(node);
+        this.setSelected(index);
+        return;
+      }
+    } while ((node = node.parentNode) !== null);
+  },
+  handleKeyDown: function handleKeyDown(e) {
+    if (isTabNode(e.target)) {
+      var index = this.state.selectedIndex;
+      var preventDefault = false;
+
+      // Select next tab to the left
+      if (e.keyCode === 37 || e.keyCode === 38) {
+        index = this.getPrevTab(index);
+        preventDefault = true;
+      }
+      // Select next tab to the right
+      /* eslint brace-style:0 */
+      else if (e.keyCode === 39 || e.keyCode === 40) {
+          index = this.getNextTab(index);
+          preventDefault = true;
+        }
+
+      // This prevents scrollbars from moving around
+      if (preventDefault) {
+        e.preventDefault();
+      }
+
+      this.setSelected(index, true);
+    }
+  },
+  setSelected: function setSelected(index, focus) {
+    // Don't do anything if nothing has changed
+    if (index === this.state.selectedIndex) return;
+    // Check index boundary
+    if (index < 0 || index >= this.getTabsCount()) return;
+
+    // Keep reference to last index for event handler
+    var last = this.state.selectedIndex;
+
+    // Update selected index
+    this.setState({ selectedIndex: index, focus: focus === true });
+
+    // Call change event handler
+    if (typeof this.props.onSelect === 'function') {
+      this.props.onSelect(index, last);
+    }
+  },
+  getNextTab: function getNextTab(index) {
+    var count = this.getTabsCount();
+
+    // Look for non-disabled tab from index to the last tab on the right
+    for (var i = index + 1; i < count; i++) {
+      var tab = this.getTab(i);
+      if (!isTabDisabled((0, _reactDom.findDOMNode)(tab))) {
+        return i;
+      }
+    }
+
+    // If no tab found, continue searching from first on left to index
+    for (var _i = 0; _i < index; _i++) {
+      var _tab = this.getTab(_i);
+      if (!isTabDisabled((0, _reactDom.findDOMNode)(_tab))) {
+        return _i;
+      }
+    }
+
+    // No tabs are disabled, return index
+    return index;
+  },
+  getPrevTab: function getPrevTab(index) {
+    var i = index;
+
+    // Look for non-disabled tab from index to first tab on the left
+    while (i--) {
+      var tab = this.getTab(i);
+      if (!isTabDisabled((0, _reactDom.findDOMNode)(tab))) {
+        return i;
+      }
+    }
+
+    // If no tab found, continue searching from last tab on right to index
+    i = this.getTabsCount();
+    while (i-- > index) {
+      var _tab2 = this.getTab(i);
+      if (!isTabDisabled((0, _reactDom.findDOMNode)(_tab2))) {
+        return i;
+      }
+    }
+
+    // No tabs are disabled, return index
+    return index;
+  },
+  getTabsCount: function getTabsCount() {
+    return this.props.children && this.props.children[0] ? _react2.default.Children.count(this.props.children[0].props.children) : 0;
+  },
+  getPanelsCount: function getPanelsCount() {
+    return _react2.default.Children.count(this.props.children.slice(1));
+  },
+  getTabList: function getTabList() {
+    return this.refs.tablist;
+  },
+  getTab: function getTab(index) {
+    return this.refs['tabs-' + index];
+  },
+  getPanel: function getPanel(index) {
+    return this.refs['panels-' + index];
+  },
+  getChildren: function getChildren() {
+    var index = 0;
+    var count = 0;
+    var children = this.props.children;
+    var state = this.state;
+    var tabIds = this.tabIds = this.tabIds || [];
+    var panelIds = this.panelIds = this.panelIds || [];
+    var diff = this.tabIds.length - this.getTabsCount();
+
+    // Add ids if new tabs have been added
+    // Don't bother removing ids, just keep them in case they are added again
+    // This is more efficient, and keeps the uuid counter under control
+    while (diff++ < 0) {
+      tabIds.push((0, _uuid2.default)(state.tabPostfix));
+      panelIds.push((0, _uuid2.default)(state.tabPostfix));
+    }
+
+    // Map children to dynamically setup refs
+    return _react2.default.Children.map(children, function (child) {
+      // null happens when conditionally rendering TabPanel/Tab
+      // see https://github.com/rackt/react-tabs/issues/37
+      if (child === null) {
+        return null;
+      }
+
+      var result = null;
+
+      // Clone TabList and Tab components to have refs
+      if (count++ === 0) {
+        // TODO try setting the uuid in the "constructor" for `Tab`/`TabPanel`
+        result = (0, _react.cloneElement)(child, {
+          ref: 'tablist',
+          children: _react2.default.Children.map(child.props.children, function (tab) {
+            // null happens when conditionally rendering TabPanel/Tab
+            // see https://github.com/rackt/react-tabs/issues/37
+            if (tab === null) {
+              return null;
+            }
+
+            var ref = 'tabs-' + index;
+            var id = tabIds[index];
+            var panelId = panelIds[index];
+            var selected = state.selectedIndex === index;
+            var focus = selected && state.focus;
+
+            index++;
+
+            return (0, _react.cloneElement)(tab, {
+              ref: ref,
+              id: id,
+              panelId: panelId,
+              selected: selected,
+              focus: focus
+            });
+          })
+        });
+
+        // Reset index for panels
+        index = 0;
+      }
+      // Clone TabPanel components to have refs
+      else {
+          var ref = 'panels-' + index;
+          var id = panelIds[index];
+          var tabId = tabIds[index];
+          var selected = state.selectedIndex === index;
+
+          index++;
+
+          result = (0, _react.cloneElement)(child, {
+            ref: ref,
+            id: id,
+            tabId: tabId,
+            selected: selected
+          });
+        }
+
+      return result;
+    });
+  },
+  render: function render() {
+    var _this = this;
+
+    // This fixes an issue with focus management.
+    //
+    // Ultimately, when focus is true, and an input has focus,
+    // and any change on that input causes a state change/re-render,
+    // focus gets sent back to the active tab, and input loses focus.
+    //
+    // Since the focus state only needs to be remembered
+    // for the current render, we can reset it once the
+    // render has happened.
+    //
+    // Don't use setState, because we don't want to re-render.
+    //
+    // See https://github.com/rackt/react-tabs/pull/7
+    if (this.state.focus) {
+      setTimeout(function () {
+        _this.state.focus = false;
+      }, 0);
+    }
+
+    return _react2.default.createElement(
+      'div',
+      {
+        className: (0, _classnames2.default)('ReactTabs', 'react-tabs', this.props.className),
+        onClick: this.handleClick,
+        onKeyDown: this.handleKeyDown
+      },
+      this.getChildren()
+    );
+  },
+
+
+  // This is an anti-pattern, so sue me
+  copyPropsToState: function copyPropsToState(props) {
+    var selectedIndex = props.selectedIndex;
+
+    // If no selectedIndex prop was supplied, then try
+    // preserving the existing selectedIndex from state.
+    // If the state has not selectedIndex, default
+    // to the first tab in the TabList.
+    //
+    // TODO: Need automation testing around this
+    // Manual testing can be done using examples/focus
+    // See 'should preserve selectedIndex when typing' in specs/Tabs.spec.js
+    if (selectedIndex === -1) {
+      if (this.state && this.state.selectedIndex) {
+        selectedIndex = this.state.selectedIndex;
+      } else {
+        selectedIndex = 0;
+      }
+    }
+
+    return {
+      selectedIndex: selectedIndex,
+      focus: props.focus
+    };
+  }
+});

--- a/dist/components/__tests__/Tab-test.js
+++ b/dist/components/__tests__/Tab-test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require('react-dom');
+
+var _reactAddonsTestUtils = require('react-addons-test-utils');
+
+var _reactAddonsTestUtils2 = _interopRequireDefault(_reactAddonsTestUtils);
+
+var _main = require('../../main');
+
+var _assert = require('assert');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/* eslint func-names:0 */
+describe('Tab', function () {
+  it('should have sane defaults', function () {
+    var tab = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(_main.Tab, null));
+    var node = (0, _reactDom.findDOMNode)(tab);
+
+    (0, _assert.equal)(node.className, 'ReactTabs__Tab');
+    (0, _assert.equal)(node.getAttribute('role'), 'tab');
+    (0, _assert.equal)(node.getAttribute('aria-selected'), 'false');
+    (0, _assert.equal)(node.getAttribute('aria-expanded'), 'false');
+    (0, _assert.equal)(node.getAttribute('aria-disabled'), 'false');
+    (0, _assert.equal)(node.getAttribute('aria-controls'), null);
+    (0, _assert.equal)(node.getAttribute('id'), null);
+    (0, _assert.equal)(node.innerHTML, '');
+  });
+
+  it('should accept className', function () {
+    var tab = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(_main.Tab, { className: 'foobar' }));
+    var node = (0, _reactDom.findDOMNode)(tab);
+
+    (0, _assert.equal)(node.className, 'ReactTabs__Tab foobar');
+  });
+
+  it('should support being selected', function () {
+    var tab = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(
+      _main.Tab,
+      { selected: true, id: 'abcd', panelId: '1234' },
+      'Hello'
+    ));
+    var node = (0, _reactDom.findDOMNode)(tab);
+
+    (0, _assert.equal)(node.className, 'ReactTabs__Tab ReactTabs__Tab--selected');
+    (0, _assert.equal)(node.getAttribute('aria-selected'), 'true');
+    (0, _assert.equal)(node.getAttribute('aria-expanded'), 'true');
+    (0, _assert.equal)(node.getAttribute('aria-controls'), '1234');
+    (0, _assert.equal)(node.getAttribute('id'), 'abcd');
+    (0, _assert.equal)(node.innerHTML, 'Hello');
+  });
+
+  it('should support being disabled', function () {
+    var tab = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(_main.Tab, { disabled: true }));
+    var node = (0, _reactDom.findDOMNode)(tab);
+
+    (0, _assert.equal)(node.className, 'ReactTabs__Tab ReactTabs__Tab--disabled');
+  });
+});

--- a/dist/components/__tests__/TabList-test.js
+++ b/dist/components/__tests__/TabList-test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require('react-dom');
+
+var _reactAddonsTestUtils = require('react-addons-test-utils');
+
+var _reactAddonsTestUtils2 = _interopRequireDefault(_reactAddonsTestUtils);
+
+var _main = require('../../main');
+
+var _assert = require('assert');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/* eslint func-names:0 */
+describe('Tab', function () {
+  it('should have sane defaults', function () {
+    var tabList = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(_main.TabList, null));
+    var node = (0, _reactDom.findDOMNode)(tabList);
+
+    (0, _assert.equal)(node.className, 'ReactTabs__TabList');
+    (0, _assert.equal)(node.getAttribute('role'), 'tablist');
+  });
+
+  it('should accept className', function () {
+    var tabList = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(_main.TabList, { className: 'foobar' }));
+    var node = (0, _reactDom.findDOMNode)(tabList);
+
+    (0, _assert.equal)(node.className, 'ReactTabs__TabList foobar');
+  });
+});

--- a/dist/components/__tests__/TabPanel-test.js
+++ b/dist/components/__tests__/TabPanel-test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require('react-dom');
+
+var _reactAddonsTestUtils = require('react-addons-test-utils');
+
+var _reactAddonsTestUtils2 = _interopRequireDefault(_reactAddonsTestUtils);
+
+var _main = require('../../main');
+
+var _assert = require('assert');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/* eslint func-names:0 */
+describe('Tab', function () {
+  it('should have sane defaults', function () {
+    var tabPanel = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(
+      _main.TabPanel,
+      null,
+      'Hola'
+    ));
+    var node = (0, _reactDom.findDOMNode)(tabPanel);
+
+    (0, _assert.equal)(node.className, 'ReactTabs__TabPanel');
+    (0, _assert.equal)(node.getAttribute('role'), 'tabpanel');
+    (0, _assert.equal)(node.getAttribute('aria-labelledby'), null);
+    (0, _assert.equal)(node.getAttribute('id'), null);
+    (0, _assert.equal)(node.innerHTML, '');
+    (0, _assert.equal)(node.style.display, 'none');
+  });
+
+  it('should accept className', function () {
+    var tabPanel = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(_main.TabPanel, { className: 'foobar' }));
+    var node = (0, _reactDom.findDOMNode)(tabPanel);
+
+    (0, _assert.equal)(node.className, 'ReactTabs__TabPanel foobar');
+  });
+
+  it('should support being selected', function () {
+    var tabPanel = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(
+      _main.TabPanel,
+      { selected: true, id: 'abcd', tabId: '1234' },
+      'Hola'
+    ));
+    var node = (0, _reactDom.findDOMNode)(tabPanel);
+
+    (0, _assert.equal)(node.className, 'ReactTabs__TabPanel ReactTabs__TabPanel--selected');
+    (0, _assert.equal)(node.getAttribute('aria-labelledby'), '1234');
+    (0, _assert.equal)(node.getAttribute('id'), 'abcd');
+    (0, _assert.equal)(node.innerHTML, 'Hola');
+    (0, _assert.equal)(node.style.display, '');
+  });
+});

--- a/dist/components/__tests__/Tabs-test.js
+++ b/dist/components/__tests__/Tabs-test.js
@@ -1,0 +1,336 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require('react-dom');
+
+var _reactAddonsTestUtils = require('react-addons-test-utils');
+
+var _reactAddonsTestUtils2 = _interopRequireDefault(_reactAddonsTestUtils);
+
+var _main = require('../../main');
+
+var _assert = require('assert');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function createTabs() {
+  var props = arguments.length <= 0 || arguments[0] === undefined ? {
+    selectedIndex: 0,
+    focus: false,
+    onSelect: null,
+    forceRenderTabPanel: false,
+    className: null
+  } : arguments[0];
+
+  return _react2.default.createElement(
+    _main.Tabs,
+    props,
+    _react2.default.createElement(
+      _main.TabList,
+      null,
+      _react2.default.createElement(
+        _main.Tab,
+        null,
+        'Foo'
+      ),
+      _react2.default.createElement(
+        _main.Tab,
+        null,
+        'Bar'
+      ),
+      _react2.default.createElement(
+        _main.Tab,
+        null,
+        _react2.default.createElement(
+          'a',
+          null,
+          'Baz'
+        )
+      ),
+      _react2.default.createElement(
+        _main.Tab,
+        { disabled: true },
+        'Qux'
+      )
+    ),
+    _react2.default.createElement(
+      _main.TabPanel,
+      null,
+      'Hello Foo'
+    ),
+    _react2.default.createElement(
+      _main.TabPanel,
+      null,
+      'Hello Bar'
+    ),
+    _react2.default.createElement(
+      _main.TabPanel,
+      null,
+      'Hello Baz'
+    ),
+    _react2.default.createElement(
+      _main.TabPanel,
+      null,
+      'Hello Qux'
+    )
+  );
+}
+
+function assertTabSelected(tabs, index) {
+  (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getTab(index)).getAttribute('tabindex'), '0');
+  (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getTab(index)).getAttribute('selected'), 'selected');
+  (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getTab(index)).getAttribute('aria-selected'), 'true');
+  (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getTab(index)).getAttribute('aria-expanded'), 'true');
+  (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(index)).style.display, '');
+}
+
+/* eslint func-names:0 */
+describe('react-tabs', function () {
+  describe('props', function () {
+    it('should default to selectedIndex being 0', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs());
+
+      assertTabSelected(tabs, 0);
+    });
+
+    it('should honor selectedIndex prop', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs({ selectedIndex: 1 }));
+
+      assertTabSelected(tabs, 1);
+    });
+
+    it('should call onSelect when selection changes', function () {
+      var called = { index: -1, last: -1 };
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs({
+        onSelect: function onSelect(index, last) {
+          called.index = index;
+          called.last = last;
+        }
+      }));
+
+      tabs.setSelected(2);
+      (0, _assert.equal)(called.index, 2);
+      (0, _assert.equal)(called.last, 0);
+    });
+
+    it('should have a default className', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs());
+      var node = (0, _reactDom.findDOMNode)(tabs);
+
+      (0, _assert.equal)(node.className, 'ReactTabs react-tabs');
+    });
+
+    it('should accept className', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs({ className: 'foobar' }));
+      var node = (0, _reactDom.findDOMNode)(tabs);
+
+      (0, _assert.equal)(node.className, 'ReactTabs react-tabs foobar');
+    });
+  });
+
+  describe('a11y', function () {
+    it('should have appropriate role and aria attributes', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs());
+
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getTabList()).getAttribute('role'), 'tablist');
+
+      for (var i = 0, l = tabs.getTabsCount(); i < l; i++) {
+        var tab = (0, _reactDom.findDOMNode)(tabs.getTab(i));
+        var panel = (0, _reactDom.findDOMNode)(tabs.getPanel(i));
+
+        (0, _assert.equal)(tab.getAttribute('role'), 'tab');
+        (0, _assert.equal)(panel.getAttribute('role'), 'tabpanel');
+
+        (0, _assert.equal)(tab.getAttribute('aria-controls'), panel.getAttribute('id'));
+        (0, _assert.equal)(panel.getAttribute('aria-labelledby'), tab.getAttribute('id'));
+      }
+
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getTab(3)).getAttribute('aria-disabled'), 'true');
+    });
+  });
+
+  describe('interaction', function () {
+    it('should update selectedIndex when clicked', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs());
+
+      _reactAddonsTestUtils2.default.Simulate.click((0, _reactDom.findDOMNode)(tabs.getTab(1)));
+      assertTabSelected(tabs, 1);
+    });
+
+    it('should update selectedIndex when tab child is clicked', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs());
+
+      _reactAddonsTestUtils2.default.Simulate.click((0, _reactDom.findDOMNode)(tabs.getTab(2)).firstChild);
+      assertTabSelected(tabs, 2);
+    });
+
+    it('should not change selectedIndex when clicking a disabled tab', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs({ selectedIndex: 0 }));
+
+      _reactAddonsTestUtils2.default.Simulate.click((0, _reactDom.findDOMNode)(tabs.getTab(3)));
+      assertTabSelected(tabs, 0);
+    });
+
+    // TODO: Can't seem to make this fail when removing fix :`(
+    // See https://github.com/rackt/react-tabs/pull/7
+    // it('should preserve selectedIndex when typing', function () {
+    //   let App = React.createClass({
+    //     handleKeyDown: function () { this.forceUpdate(); },
+    //     render: function () {
+    //       return (
+    //         <Tabs ref="tabs" selectedIndex={1}>
+    //           <TabList>
+    //             <Tab>First</Tab>
+    //             <Tab>Second</Tab>
+    //           </TabList>
+    //           <TabPanel>1st</TabPanel>
+    //           <TabPanel><input onKeyDown={this.handleKeyDown}/></TabPanel>
+    //         </Tabs>
+    //       );
+    //     }
+    //   });
+    //
+    //   let tabs = TestUtils.renderIntoDocument(<App/>).refs.tabs;
+    //   let input = tabs.getDOMNode().querySelector('input');
+    //
+    //   input.focus();
+    //   TestUtils.Simulate.keyDown(input, {
+    //     keyCode: 'a'.charCodeAt()
+    //   });
+    //
+    //   assertTabSelected(tabs, 1);
+    // });
+  });
+
+  describe('performance', function () {
+    it('should only render the active tab panel', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs());
+
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(0)).innerHTML, 'Hello Foo');
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(1)).innerHTML, '');
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(2)).innerHTML, '');
+
+      _reactAddonsTestUtils2.default.Simulate.click((0, _reactDom.findDOMNode)(tabs.getTab(1)));
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(0)).innerHTML, '');
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(1)).innerHTML, 'Hello Bar');
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(2)).innerHTML, '');
+
+      _reactAddonsTestUtils2.default.Simulate.click((0, _reactDom.findDOMNode)(tabs.getTab(2)));
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(0)).innerHTML, '');
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(1)).innerHTML, '');
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(2)).innerHTML, 'Hello Baz');
+    });
+
+    it('should render all tabs if forceRenderTabPanel is true', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(createTabs({ forceRenderTabPanel: true }));
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(0)).innerHTML, 'Hello Foo');
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(1)).innerHTML, 'Hello Bar');
+      (0, _assert.equal)((0, _reactDom.findDOMNode)(tabs.getPanel(2)).innerHTML, 'Hello Baz');
+    });
+  });
+
+  describe('validation', function () {
+    it('should result with warning when tabs/panels are imbalanced', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(
+        _main.Tabs,
+        null,
+        _react2.default.createElement(
+          _main.TabList,
+          null,
+          _react2.default.createElement(
+            _main.Tab,
+            null,
+            'Foo'
+          )
+        )
+      ));
+
+      var result = _main.Tabs.propTypes.children(tabs.props, 'children', 'Tabs');
+      (0, _assert.ok)(result instanceof Error);
+    });
+
+    it('should result with a warning when wrong element is found', function () {
+      var tabs = _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(
+        _main.Tabs,
+        null,
+        _react2.default.createElement(
+          _main.TabList,
+          null,
+          _react2.default.createElement(_main.Tab, null),
+          _react2.default.createElement('div', null)
+        ),
+        _react2.default.createElement(_main.TabPanel, null)
+      ));
+
+      var result = _main.Tabs.propTypes.children(tabs.props, 'children', 'Tabs');
+      (0, _assert.ok)(result instanceof Error);
+    });
+
+    it('should be okay with rendering without any children', function () {
+      var error = false;
+      try {
+        _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(_main.Tabs, null));
+      } catch (e) {
+        error = true;
+      }
+
+      (0, _assert.ok)(!error);
+    });
+
+    it('should be okay with rendering just TabList', function () {
+      var error = false;
+      try {
+        _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(
+          _main.Tabs,
+          null,
+          _react2.default.createElement(_main.TabList, null)
+        ));
+      } catch (e) {
+        error = true;
+      }
+
+      (0, _assert.ok)(!error);
+    });
+
+    it('should gracefully render null', function () {
+      var error = false;
+      try {
+        _reactAddonsTestUtils2.default.renderIntoDocument(_react2.default.createElement(
+          _main.Tabs,
+          null,
+          _react2.default.createElement(
+            _main.TabList,
+            null,
+            _react2.default.createElement(
+              _main.Tab,
+              null,
+              'Tab A'
+            ),
+            false && _react2.default.createElement(
+              _main.Tab,
+              null,
+              'Tab B'
+            )
+          ),
+          _react2.default.createElement(
+            _main.TabPanel,
+            null,
+            'Content A'
+          ),
+          false && _react2.default.createElement(
+            _main.TabPanel,
+            null,
+            'Content B'
+          )
+        ));
+      } catch (e) {
+        error = true;
+      }
+
+      (0, _assert.ok)(!error);
+    });
+  });
+});

--- a/dist/helpers/childrenPropType.js
+++ b/dist/helpers/childrenPropType.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _Tab = require('../components/Tab');
+
+var _Tab2 = _interopRequireDefault(_Tab);
+
+var _TabList = require('../components/TabList');
+
+var _TabList2 = _interopRequireDefault(_TabList);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+module.exports = function childrenPropTypes(props, propName) {
+  var error = void 0;
+  var tabsCount = 0;
+  var panelsCount = 0;
+  var children = props[propName];
+
+  _react2.default.Children.forEach(children, function (child) {
+    // null happens when conditionally rendering TabPanel/Tab
+    // see https://github.com/rackt/react-tabs/issues/37
+    if (child === null) {
+      return;
+    }
+
+    if (child.type === _TabList2.default) {
+      _react2.default.Children.forEach(child.props.children, function (c) {
+        // null happens when conditionally rendering TabPanel/Tab
+        // see https://github.com/rackt/react-tabs/issues/37
+        if (c === null) {
+          return;
+        }
+
+        if (c.type === _Tab2.default) {
+          tabsCount++;
+        } else {
+          error = new Error('Expected `Tab` but found `' + (c.type.displayName || c.type) + '`');
+        }
+      });
+    } else if (child.type.displayName === 'TabPanel') {
+      panelsCount++;
+    } else {
+      error = new Error('Expected `TabList` or `TabPanel` but found `' + (child.type.displayName || child.type) + '`');
+    }
+  });
+
+  if (tabsCount !== panelsCount) {
+    error = new Error('There should be an equal number of `Tabs` and `TabPanels`. ' + 'Received ' + tabsCount + ' `Tabs` and ' + panelsCount + ' `TabPanels`.');
+  }
+
+  return error;
+};

--- a/dist/helpers/styles.js
+++ b/dist/helpers/styles.js
@@ -1,0 +1,50 @@
+'use strict';
+
+module.exports = {
+  '.react-tabs [role=tablist]': {
+    'border-bottom': '1px solid #aaa',
+    'margin': '0 0 10px',
+    'padding': '0'
+  },
+
+  '.react-tabs [role=tab]': {
+    'display': 'inline-block',
+    'border': '1px solid transparent',
+    'border-bottom': 'none',
+    'bottom': '-1px',
+    'position': 'relative',
+    'list-style': 'none',
+    'padding': '6px 12px',
+    'cursor': 'pointer'
+  },
+
+  '.react-tabs [role=tab][aria-selected=true]': {
+    'background': '#fff',
+    'border-color': '#aaa',
+    'color': 'black',
+    'border-radius': '5px 5px 0 0',
+    '-moz-border-radius': '5px 5px 0 0',
+    '-webkit-border-radius': '5px 5px 0 0'
+  },
+
+  '.react-tabs [role=tab][aria-disabled=true]': {
+    'color': 'GrayText',
+    'cursor': 'default'
+  },
+
+  '.react-tabs [role=tab]:focus': {
+    'box-shadow': '0 0 5px hsl(208, 99%, 50%)',
+    'border-color': 'hsl(208, 99%, 50%)',
+    'outline': 'none'
+  },
+
+  '.react-tabs [role=tab]:focus:after': {
+    'content': '""',
+    'position': 'absolute',
+    'height': '5px',
+    'left': '-4px',
+    'right': '-4px',
+    'bottom': '-5px',
+    'background': '#fff'
+  }
+};

--- a/dist/helpers/uuid.js
+++ b/dist/helpers/uuid.js
@@ -1,0 +1,7 @@
+'use strict';
+
+// Get a universally unique identifier
+var count = 0;
+module.exports = function uuid(id) {
+  return id ? 'react-tabs-' + count++ + '-' + id : 'react-tabs-' + count++;
+};

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  Tabs: require('./components/Tabs'),
+  TabList: require('./components/TabList'),
+  Tab: require('./components/Tab'),
+  TabPanel: require('./components/TabPanel')
+};

--- a/lib/components/Tabs.js
+++ b/lib/components/Tabs.js
@@ -2,9 +2,9 @@ import React, {PropTypes, cloneElement} from 'react';
 import { findDOMNode } from 'react-dom';
 import cx from 'classnames';
 import jss from 'js-stylesheet';
-import uuid from '../helpers/uuid';
+import UUID from '../helpers/uuid';
 import childrenPropType from '../helpers/childrenPropType';
-
+const uuid = UUID()
 // Determine if a node from event.target is a Tab element
 function isTabNode(node) {
   return node.nodeName === 'LI' && node.getAttribute('role') === 'tab';
@@ -43,8 +43,7 @@ module.exports = React.createClass({
     return {
       selectedIndex: -1,
       focus: false,
-      forceRenderTabPanel: false,
-      tabCount: 0
+      forceRenderTabPanel: false
     };
   },
 
@@ -209,8 +208,8 @@ module.exports = React.createClass({
     // Don't bother removing ids, just keep them in case they are added again
     // This is more efficient, and keeps the uuid counter under control
     while (diff++ < 0) {
-      tabIds.push(uuid(this.tabCount++));
-      panelIds.push(uuid(this.tabCount++));
+      tabIds.push(uuid());
+      panelIds.push(uuid());
     }
 
     // Map children to dynamically setup refs

--- a/lib/components/Tabs.js
+++ b/lib/components/Tabs.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import jss from 'js-stylesheet';
 import uuid from '../helpers/uuid';
 import childrenPropType from '../helpers/childrenPropType';
+
 // Determine if a node from event.target is a Tab element
 function isTabNode(node) {
   return node.nodeName === 'LI' && node.getAttribute('role') === 'tab';

--- a/lib/components/Tabs.js
+++ b/lib/components/Tabs.js
@@ -2,9 +2,8 @@ import React, {PropTypes, cloneElement} from 'react';
 import { findDOMNode } from 'react-dom';
 import cx from 'classnames';
 import jss from 'js-stylesheet';
-import UUID from '../helpers/uuid';
+import uuid from '../helpers/uuid';
 import childrenPropType from '../helpers/childrenPropType';
-const uuid = UUID()
 // Determine if a node from event.target is a Tab element
 function isTabNode(node) {
   return node.nodeName === 'LI' && node.getAttribute('role') === 'tab';
@@ -26,7 +25,8 @@ module.exports = React.createClass({
     onSelect: PropTypes.func,
     focus: PropTypes.bool,
     children: childrenPropType,
-    forceRenderTabPanel: PropTypes.bool
+    forceRenderTabPanel: PropTypes.bool,
+    tabPostfix: PropTypes.string
   },
 
   childContextTypes: {
@@ -208,8 +208,8 @@ module.exports = React.createClass({
     // Don't bother removing ids, just keep them in case they are added again
     // This is more efficient, and keeps the uuid counter under control
     while (diff++ < 0) {
-      tabIds.push(uuid());
-      panelIds.push(uuid());
+      tabIds.push(uuid(state.tabPostfix));
+      panelIds.push(uuid(state.tabPostfix));
     }
 
     // Map children to dynamically setup refs

--- a/lib/components/Tabs.js
+++ b/lib/components/Tabs.js
@@ -43,7 +43,8 @@ module.exports = React.createClass({
     return {
       selectedIndex: -1,
       focus: false,
-      forceRenderTabPanel: false
+      forceRenderTabPanel: false,
+      tabCount: 0
     };
   },
 
@@ -208,8 +209,8 @@ module.exports = React.createClass({
     // Don't bother removing ids, just keep them in case they are added again
     // This is more efficient, and keeps the uuid counter under control
     while (diff++ < 0) {
-      tabIds.push(uuid());
-      panelIds.push(uuid());
+      tabIds.push(uuid(this.tabCount++));
+      panelIds.push(uuid(this.tabCount++));
     }
 
     // Map children to dynamically setup refs

--- a/lib/helpers/uuid.js
+++ b/lib/helpers/uuid.js
@@ -1,4 +1,7 @@
 // Get a universally unique identifier
-module.exports = function uuid(count) {
-  return 'react-tabs-' + count;
+module.exports = function uuid() {
+  count = 0;
+  return function() {
+    'react-tabs-' + count; 
+  }
 };

--- a/lib/helpers/uuid.js
+++ b/lib/helpers/uuid.js
@@ -1,6 +1,6 @@
 // Get a universally unique identifier
 let count = 0;
-module.exports =  function generateUUID(id) {
+module.exports =  function uuid(id) {
   count++;
   return (id) 
     ? 'react-tabs-' + count + '-' + id

--- a/lib/helpers/uuid.js
+++ b/lib/helpers/uuid.js
@@ -1,7 +1,7 @@
 // Get a universally unique identifier
 let count = 0;
 module.exports =  function uuid(id) {
-  return (id) 
+  return (id)
     ? 'react-tabs-' + (count++) + '-' + id
     : 'react-tabs-' + (count++);
 };

--- a/lib/helpers/uuid.js
+++ b/lib/helpers/uuid.js
@@ -1,8 +1,7 @@
 // Get a universally unique identifier
 let count = 0;
 module.exports =  function uuid(id) {
-  count++;
   return (id) 
-    ? 'react-tabs-' + count + '-' + id
-    : 'react-tabs-' + count;
+    ? 'react-tabs-' + (count++) + '-' + id
+    : 'react-tabs-' + (count++);
 };

--- a/lib/helpers/uuid.js
+++ b/lib/helpers/uuid.js
@@ -1,7 +1,9 @@
+
 // Get a universally unique identifier
-module.exports = function uuid() {
-  count = 0;
-  return function() {
-    'react-tabs-' + count; 
-  }
+let count = 0;
+module.exports =  function generateUUID(id) {
+  count++;
+  return (id) 
+    ? 'react-tabs-' + count + '-' + id
+    : 'react-tabs-' + count;
 };

--- a/lib/helpers/uuid.js
+++ b/lib/helpers/uuid.js
@@ -1,5 +1,4 @@
 // Get a universally unique identifier
-let count = 0;
-module.exports = function uuid() {
-  return 'react-tabs-' + count++;
+module.exports = function uuid(count) {
+  return 'react-tabs-' + count;
 };

--- a/lib/helpers/uuid.js
+++ b/lib/helpers/uuid.js
@@ -1,4 +1,3 @@
-
 // Get a universally unique identifier
 let count = 0;
 module.exports =  function generateUUID(id) {


### PR DESCRIPTION
This PR allows for an optional post-fix prop value to be passed to each Tabs Component. This allows those that want to fix #56 an option to do so, and not break the way tab-uuids works for those who do not need it.

I did not add `state.tabPostfix` to the default props. This way if it is not used, it will be undefined, and uuid will return the tab-uuid like it currently does. If it is truthy, then it will be used as a post-fix on the tab-uuid.