### PR TITLE
Allow style to be set directly on `Tab` components.

### DIFF
--- a/lib/components/Tab.js
+++ b/lib/components/Tab.js
@@ -24,6 +24,7 @@ module.exports = React.createClass({
     selected: PropTypes.bool,
     disabled: PropTypes.bool,
     panelId: PropTypes.string,
+    style: PropTypes.object,
     children: PropTypes.oneOfType([
       PropTypes.array,
       PropTypes.object,
@@ -59,6 +60,7 @@ module.exports = React.createClass({
             'ReactTabs__Tab--disabled': this.props.disabled
           }
         )}
+        style={this.props.style}
         role="tab"
         id={this.props.id}
         aria-selected={this.props.selected ? 'true' : 'false'}


### PR DESCRIPTION
`Tab` components are the only things inside `Tabs` components that aren't *really* wrappers. They, in my experience, are often the actual element that users will interact with. Rather than
```jsx
<Tab><span style={style.tab}>My Tab</span></Tab>
```
It might be nice to
```jsx
<Tab style={style.tab}>My Tab</Tab>
```