### PR TITLE
Allow providing custom attributes to <Tab> (spread attributes)

### DIFF
--- a/lib/components/Tab.js
+++ b/lib/components/Tab.js
@@ -51,6 +51,13 @@ module.exports = React.createClass({
   render() {
     return (
       <li
+		role="tab"
+		id={this.props.id}
+		aria-selected={this.props.selected ? 'true' : 'false'}
+		aria-expanded={this.props.selected ? 'true' : 'false'}
+		aria-disabled={this.props.disabled ? 'true' : 'false'}
+		aria-controls={this.props.panelId}
+		{...this.props}
         className={cx(
           'ReactTabs__Tab',
           this.props.className,
@@ -59,12 +66,6 @@ module.exports = React.createClass({
             'ReactTabs__Tab--disabled': this.props.disabled
           }
         )}
-        role="tab"
-        id={this.props.id}
-        aria-selected={this.props.selected ? 'true' : 'false'}
-        aria-expanded={this.props.selected ? 'true' : 'false'}
-        aria-disabled={this.props.disabled ? 'true' : 'false'}
-        aria-controls={this.props.panelId}
       >
         {this.props.children}
       </li>

--- a/lib/components/Tab.js
+++ b/lib/components/Tab.js
@@ -51,13 +51,13 @@ module.exports = React.createClass({
   render() {
     return (
       <li
-		role="tab"
-		id={this.props.id}
-		aria-selected={this.props.selected ? 'true' : 'false'}
-		aria-expanded={this.props.selected ? 'true' : 'false'}
-		aria-disabled={this.props.disabled ? 'true' : 'false'}
-		aria-controls={this.props.panelId}
-		{...this.props}
+        role="tab"
+        id={this.props.id}
+        aria-selected={this.props.selected ? 'true' : 'false'}
+        aria-expanded={this.props.selected ? 'true' : 'false'}
+        aria-disabled={this.props.disabled ? 'true' : 'false'}
+        aria-controls={this.props.panelId}
+        {...this.props}
         className={cx(
           'ReactTabs__Tab',
           this.props.className,

--- a/lib/components/__tests__/Tab-test.js
+++ b/lib/components/__tests__/Tab-test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { findDOMNode } from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import { Tab } from '../../main';
-import { equal } from 'assert';
+import { equal, notEqual } from 'assert';
 
 /* eslint func-names:0 */
 describe('Tab', function() {
@@ -24,7 +24,7 @@ describe('Tab', function() {
     const tab = TestUtils.renderIntoDocument(<Tab className="foobar"/>);
     const node = findDOMNode(tab);
 
-    equal(node.className, 'ReactTabs__Tab foobar');
+	notEqual(node.className.indexOf('foobar'), -1);
   });
 
   it('should support being selected', function() {
@@ -44,5 +44,25 @@ describe('Tab', function() {
     const node = findDOMNode(tab);
 
     equal(node.className, 'ReactTabs__Tab ReactTabs__Tab--disabled');
+  });
+
+  it('should pass through custom properties', function() {
+    const tab = TestUtils.renderIntoDocument(<Tab data-tooltip="Tooltip contents"/>);
+    const node = findDOMNode(tab);
+
+    equal(node.getAttribute('data-tooltip'), 'Tooltip contents');
+  });
+  it('should allow overriding all default properties', function() {
+    const tab = TestUtils.renderIntoDocument(<Tab role="micro-tab"/>);
+    const node = findDOMNode(tab);
+
+    equal(node.getAttribute('role'), 'micro-tab');
+  });
+  it('should merge className instead of overriding', function() {
+    const tab = TestUtils.renderIntoDocument(<Tab className="foobar"/>);
+    const node = findDOMNode(tab);
+
+    notEqual(node.className.indexOf('ReactTabs__Tab'), -1);
+    notEqual(node.className.indexOf('foobar'), -1);
   });
 });

--- a/lib/components/__tests__/Tab-test.js
+++ b/lib/components/__tests__/Tab-test.js
@@ -24,7 +24,7 @@ describe('Tab', function() {
     const tab = TestUtils.renderIntoDocument(<Tab className="foobar"/>);
     const node = findDOMNode(tab);
 
-	notEqual(node.className.indexOf('foobar'), -1);
+    notEqual(node.className.indexOf('foobar'), -1);
   });
 
   it('should support being selected', function() {


### PR DESCRIPTION
This PR makes it possible to provide custom attributes to `<Tab>` through [attribute spreading](https://facebook.github.io/react/docs/jsx-spread.html) on the rendered `<li>` component. This allows both overriding of the existing attributes (except className) and to provide new attributes as shown in the tests.

This solves my wish to be able to set "data-tip" for tooltips with [`react-tooltip`](https://github.com/wwayne/react-tooltip), and resolves PR https://github.com/reactjs/react-tabs/pull/92 and issue https://github.com/reactjs/react-tabs/issues/44

Edit: would also provide a solution for #97 
Edit2: Oops, didn't know a PR would automatically update with new commits, moved the commits not related to this PR to a different branch and force reset master, PR should be ok now.