### PR TITLE
Allow other components inside TabList

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -17,6 +17,8 @@ const App = React.createClass({
             <Tab>React</Tab>
             <Tab>Ember</Tab>
             <Tab>Angular</Tab>
+
+            <span>+</span>
           </TabList>
 
           <TabPanel>

--- a/src/components/TabList.js
+++ b/src/components/TabList.js
@@ -3,14 +3,17 @@ import cx from 'classnames';
 
 function renderChildren(props) {
   return React.Children.map(props.children, (child) => {
-    let clonedProps = {};
+    // if child is not a tab we don't need to clone it
+    // since we don't need to add custom props
 
-    if (child.type.displayName === 'Tab') {
-      clonedProps = {
-        activeTabClassName: props.activeTabClassName,
-        disabledTabClassName: props.disabledTabClassName,
-      };
+    if (child.type.displayName !== 'Tab') {
+      return child;
     }
+
+    const clonedProps = {
+      activeTabClassName: props.activeTabClassName,
+      disabledTabClassName: props.disabledTabClassName,
+    };
 
     return React.cloneElement(child, clonedProps);
   });

--- a/src/components/TabList.js
+++ b/src/components/TabList.js
@@ -2,12 +2,18 @@ import React, { PropTypes } from 'react';
 import cx from 'classnames';
 
 function renderChildren(props) {
-  return React.Children.map(props.children, (child) =>
-    React.cloneElement(child, {
-      activeTabClassName: props.activeTabClassName,
-      disabledTabClassName: props.disabledTabClassName,
-    })
-  );
+  return React.Children.map(props.children, (child) => {
+    let clonedProps = {};
+
+    if (child.type.displayName === 'Tab') {
+      clonedProps = {
+        activeTabClassName: props.activeTabClassName,
+        disabledTabClassName: props.disabledTabClassName,
+      };
+    }
+
+    return React.cloneElement(child, clonedProps);
+  });
 }
 
 module.exports = React.createClass({

--- a/src/components/TabList.js
+++ b/src/components/TabList.js
@@ -1,12 +1,13 @@
 import React, { PropTypes } from 'react';
 import cx from 'classnames';
+import Tab from './Tab';
 
 function renderChildren(props) {
   return React.Children.map(props.children, (child) => {
     // if child is not a tab we don't need to clone it
     // since we don't need to add custom props
 
-    if (child.type.displayName !== 'Tab') {
+    if (child.type !== Tab) {
       return child;
     }
 

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import jss from 'js-stylesheet';
 import uuid from '../helpers/uuid';
 import childrenPropType from '../helpers/childrenPropType';
+import Tab from './Tab';
 
 // Determine if a node from event.target is a Tab element
 function isTabNode(node) {
@@ -209,7 +210,7 @@ module.exports = React.createClass({
 
             index++;
 
-            if (tab.type.displayName === 'Tab') {
+            if (tab.type === Tab) {
               return cloneElement(tab, {
                 ref,
                 id,

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -207,15 +207,21 @@ module.exports = React.createClass({
             const selected = state.selectedIndex === index;
             const focus = selected && state.focus;
 
-            index++;
-
-            return cloneElement(tab, {
+            let props = {
               ref,
               id,
               panelId,
               selected,
               focus,
-            });
+            };
+
+            if (tab.type.displayName !== 'Tab') {
+              props = {};
+            }
+
+            index++;
+
+            return cloneElement(tab, props);
           }),
         });
 

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -207,21 +207,19 @@ module.exports = React.createClass({
             const selected = state.selectedIndex === index;
             const focus = selected && state.focus;
 
-            let props = {
-              ref,
-              id,
-              panelId,
-              selected,
-              focus,
-            };
-
-            if (tab.type.displayName !== 'Tab') {
-              props = {};
-            }
-
             index++;
 
-            return cloneElement(tab, props);
+            if (tab.type.displayName === 'Tab') {
+              return cloneElement(tab, {
+                ref,
+                id,
+                panelId,
+                selected,
+                focus,
+              });
+            }
+
+            return tab;
           }),
         });
 

--- a/src/components/__tests__/Tabs-test.js
+++ b/src/components/__tests__/Tabs-test.js
@@ -201,7 +201,24 @@ describe('react-tabs', () => {
       expect(result instanceof Error).toBe(true);
     });
 
-    it('should result with a warning when wrong element is found', () => {
+    it('should result with warning when tabs/panels are imbalanced ignoring non tab children', () => {
+      const wrapper = shallow(
+        <Tabs>
+          <TabList>
+            <Tab>Foo</Tab>
+            <div>+</div>
+          </TabList>
+
+          <TabPanel>Hello Foo</TabPanel>
+          <TabPanel>Hello Bar</TabPanel>
+        </Tabs>
+      );
+
+      const result = Tabs.propTypes.children(wrapper.props(), 'children', 'Tabs');
+      expect(result instanceof Error).toBe(true);
+    });
+
+    it('should not throw a warning when wrong element is found', () => {
       const wrapper = shallow(
         <Tabs>
           <TabList>
@@ -213,7 +230,7 @@ describe('react-tabs', () => {
       );
 
       const result = Tabs.propTypes.children(wrapper.props(), 'children', 'Tabs');
-      expect(result instanceof Error).toBe(true);
+      expect(result instanceof Error).toBe(false);
     });
 
     it('should be okay with rendering without any children', () => {

--- a/src/components/__tests__/Tabs-test.js
+++ b/src/components/__tests__/Tabs-test.js
@@ -185,6 +185,27 @@ describe('react-tabs', () => {
       expect(wrapper.childAt(2).text()).toBe('Hello Bar');
       expect(wrapper.childAt(3).text()).toBe('Hello Baz');
     });
+
+    it('should not clone non tabs element', () => {
+      class Demo extends React.Component {
+        render() {
+          const plus = <div ref="yolo">+</div>;
+
+          return (<Tabs>
+            <TabList>
+              <Tab>Foo</Tab>
+              {plus}
+            </TabList>
+
+            <TabPanel>Hello Baz</TabPanel>
+          </Tabs>);
+        }
+      }
+
+      const wrapper = mount(<Demo />);
+
+      expect(wrapper.ref('yolo').text()).toBe('+');
+    });
   });
 
   describe('validation', () => {

--- a/src/components/__tests__/Tabs-test.js
+++ b/src/components/__tests__/Tabs-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 /* global jest, describe, it, expect */
 import React from 'react';
 import { shallow, mount } from 'enzyme';

--- a/src/components/__tests__/Tabs-test.js
+++ b/src/components/__tests__/Tabs-test.js
@@ -201,7 +201,8 @@ describe('react-tabs', () => {
       expect(result instanceof Error).toBe(true);
     });
 
-    it('should result with warning when tabs/panels are imbalanced ignoring non tab children', () => {
+    it(`should result with warning when tabs/panels are imbalanced and
+        it should ignore non tab children`, () => {
       const wrapper = shallow(
         <Tabs>
           <TabList>

--- a/src/helpers/childrenPropType.js
+++ b/src/helpers/childrenPropType.js
@@ -25,10 +25,6 @@ module.exports = function childrenPropTypes(props, propName) {
 
         if (c.type === Tab) {
           tabsCount++;
-        } else {
-          error = new Error(
-            `Expected 'Tab' but found '${c.type.displayName || c.type}'`
-          );
         }
       });
     } else if (child.type.displayName === 'TabPanel') {


### PR DESCRIPTION
Allows to add additional elements inside a TabList.
I've disabled the check that was throwing a warning when an element different from Tab was added to the TabList. Seems working well.

I needed to do this since I need to add a fake tab at the end of the TabList, like this:
```html
<Tabs>
  <TabList>
    <Tab>Foo</Tab>
    <div>+</div>
  </TabList>
  
  <TabPanel>Hello</TabPanel>
</Tabs>
```

Maybe we can do the same for TabPanels, if needed.
Let me know your thoughts :)