### PR TITLE
require 'react-dom' but still use window.ReactDOM with globals

### DIFF
--- a/webpack.build.js
+++ b/webpack.build.js
@@ -24,8 +24,18 @@ module.exports = {
     libraryTarget: 'umd'
   },
   externals: {
-    'react': 'React',
-    'react-dom': 'ReactDOM'
+    'react': {
+      root: 'React',
+      commonjs2: 'react',
+      commonjs: 'react',
+      amd: 'react'
+    },
+    'react-dom': {
+      root: 'ReactDOM',
+      commonjs2: 'react-dom',
+      commonjs: 'react-dom',
+      amd: 'react-dom'
+    }
   },
   module: {
     loaders: [


### PR DESCRIPTION
when you export the UMD wrapper, you want to commonJS and AMD to require 'react' and 'react-dom' not 'React' and 'ReactDOM'. but you do want to use those capitalized variable names if you are using globals