### PR TITLE
Custom tabpanel selected class

### DIFF
--- a/src/components/TabPanel.js
+++ b/src/components/TabPanel.js
@@ -13,6 +13,7 @@ module.exports = React.createClass({
     className: PropTypes.string,
     id: PropTypes.string,
     selected: PropTypes.bool,
+    selectedClassName: PropTypes.string,
     style: PropTypes.object,
     tabId: PropTypes.string,
   },
@@ -24,13 +25,17 @@ module.exports = React.createClass({
   getDefaultProps() {
     return {
       selected: false,
+      selectedClassName: 'ReactTabs__TabPanel--selected',
       id: null,
       tabId: null,
     };
   },
 
   render() {
-    const { className, children, selected, id, tabId, style, ...attributes } = this.props;
+    const { className, children, selected, selectedClassName, id, tabId, style, ...attributes } = this.props;
+
+    // Only hide using inline styles if `selectedClassName` isn't provided
+    const hiddenStyle = selectedClassName ? style : { ...style, display: selected ? null : 'none' };
 
     return (
       <div
@@ -39,13 +44,13 @@ module.exports = React.createClass({
           'ReactTabs__TabPanel',
           className,
           {
-            'ReactTabs__TabPanel--selected': selected,
+            [selectedClassName]: selected,
           }
         )}
         role="tabpanel"
         id={id}
         aria-labelledby={tabId}
-        style={{ ...style, display: selected ? null : 'none' }}
+        style={selected ? style : hiddenStyle}
       >
         {(this.context.forceRenderTabPanel || selected) ? children : null}
       </div>

--- a/src/components/TabPanel.js
+++ b/src/components/TabPanel.js
@@ -25,7 +25,7 @@ module.exports = React.createClass({
   getDefaultProps() {
     return {
       selected: false,
-      selectedClassName: 'ReactTabs__TabPanel--selected',
+      selectedClassName: null,
       id: null,
       tabId: null,
     };
@@ -44,7 +44,7 @@ module.exports = React.createClass({
           'ReactTabs__TabPanel',
           className,
           {
-            [selectedClassName]: selected,
+            [selectedClassName || 'ReactTabs__TabPanel--selected']: selected,
           }
         )}
         role="tabpanel"

--- a/src/components/TabPanel.js
+++ b/src/components/TabPanel.js
@@ -33,14 +33,18 @@ module.exports = React.createClass({
   },
 
   render() {
-    const { className, children, selected, selectedClassName, id, tabId, style, ...attributes } = this.props;
+    const {
+      id, tabId, selected,
+      className, selectedClassName, style, children,
+      ...attrs,
+    } = this.props;
 
     // Only hide using inline styles if `selectedClassName` isn't provided
     const hiddenStyle = selectedClassName ? style : { ...style, display: 'none' };
 
     return (
       <div
-        {...attributes}
+        {...attrs}
         className={cx(
           'ReactTabs__TabPanel',
           className,

--- a/src/components/TabPanel.js
+++ b/src/components/TabPanel.js
@@ -26,6 +26,7 @@ module.exports = React.createClass({
     return {
       selected: false,
       selectedClassName: null,
+      style: {},
       id: null,
       tabId: null,
     };
@@ -35,7 +36,7 @@ module.exports = React.createClass({
     const { className, children, selected, selectedClassName, id, tabId, style, ...attributes } = this.props;
 
     // Only hide using inline styles if `selectedClassName` isn't provided
-    const hiddenStyle = selectedClassName ? style : { ...style, display: selected ? null : 'none' };
+    const hiddenStyle = selectedClassName ? style : { ...style, display: 'none' };
 
     return (
       <div

--- a/src/components/__tests__/TabPanel-test.js
+++ b/src/components/__tests__/TabPanel-test.js
@@ -33,7 +33,21 @@ describe('Tab', () => {
     expect(wrapper.prop('id')).toBe('abcd');
     expect(wrapper.text()).toBe('Hola');
     expect(wrapper.prop('style')).not.toBe(null);
-    expect(wrapper.prop('style').display).toBe(null);
+    expect(wrapper.prop('style').display).not.toBe('none');
+  });
+
+  it('should support a custom selected class name', () => {
+    const wrapper = shallow(<TabPanel selected selectedClassName="iAmSelected">Hola</TabPanel>);
+
+    expect(wrapper.hasClass('iAmSelected')).toBe(true);
+  });
+
+  it('should not hide using styles when a custom select class name is provided', () => {
+    const wrapper = shallow(<TabPanel selectedClassName="iAmSelected">Hola</TabPanel>);
+    const style = wrapper.prop('style');
+
+    expect(wrapper.hasClass('iAmSelected')).toBe(false);
+    expect(style && style.display).toBeFalsy();
   });
 
   it('should pass through custom properties', () => {


### PR DESCRIPTION
This PR does the following:

1. It lets you override the class name to use for currently selected `<TabPanel>`s using a new `selectedClassName` prop;
2. it only applies `display: none;` to the `<TabPanel>` if a custom `selectedClassName` prop has not been provided; and
3. adds tests.

My use case is that I need to keep the contents of hidden tabs and give them a bunch of styles in order to maintain the parent's dimensions.