### PR TITLE
Replace url references to rackt/react-tabs with reactjs/react-tabs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "react-tabs",
   "version": "0.5.3",
-  "homepage": "https://github.com/rackt/react-tabs",
+  "homepage": "https://github.com/reactjs/react-tabs",
   "authors": [
     "Matt Zabriskie"
   ],

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -183,7 +183,7 @@ module.exports = React.createClass({
     // Map children to dynamically setup refs
     return React.Children.map(children, (child) => {
       // null happens when conditionally rendering TabPanel/Tab
-      // see https://github.com/rackt/react-tabs/issues/37
+      // see https://github.com/reactjs/react-tabs/issues/37
       if (child === null) {
         return null;
       }
@@ -197,7 +197,7 @@ module.exports = React.createClass({
           ref: 'tablist',
           children: React.Children.map(child.props.children, (tab) => {
             // null happens when conditionally rendering TabPanel/Tab
-            // see https://github.com/rackt/react-tabs/issues/37
+            // see https://github.com/reactjs/react-tabs/issues/37
             if (tab === null) {
               return null;
             }
@@ -352,7 +352,7 @@ module.exports = React.createClass({
     //
     // Don't use setState, because we don't want to re-render.
     //
-    // See https://github.com/rackt/react-tabs/pull/7
+    // See https://github.com/reactjs/react-tabs/pull/7
     if (this.state.focus) {
       setTimeout(() => {
         this.state.focus = false;

--- a/src/components/__tests__/Tabs-test.js
+++ b/src/components/__tests__/Tabs-test.js
@@ -128,7 +128,7 @@ describe('react-tabs', () => {
     });
 
     // TODO: Can't seem to make this fail when removing fix :`(
-    // See https://github.com/rackt/react-tabs/pull/7
+    // See https://github.com/reactjs/react-tabs/pull/7
     // it('should preserve selectedIndex when typing', function () {
     //   let App = React.createClass({
     //     handleKeyDown: function () { this.forceUpdate(); },

--- a/src/helpers/childrenPropType.js
+++ b/src/helpers/childrenPropType.js
@@ -10,7 +10,7 @@ module.exports = function childrenPropTypes(props, propName) {
 
   React.Children.forEach(children, (child) => {
     // null happens when conditionally rendering TabPanel/Tab
-    // see https://github.com/rackt/react-tabs/issues/37
+    // see https://github.com/reactjs/react-tabs/issues/37
     if (child === null) {
       return;
     }
@@ -18,7 +18,7 @@ module.exports = function childrenPropTypes(props, propName) {
     if (child.type === TabList) {
       React.Children.forEach(child.props.children, (c) => {
         // null happens when conditionally rendering TabPanel/Tab
-        // see https://github.com/rackt/react-tabs/issues/37
+        // see https://github.com/reactjs/react-tabs/issues/37
         if (c === null) {
           return;
         }


### PR DESCRIPTION
Hi All 👋

I noticed a bad link in another project, linking to `github.com/rackt/redux` which is now held by somebody else it seems - who also have a `redux` repo, just to confuse things.

I opened a PR in that project but thought I'd have a quick look at other occurrences and noticed that there are a few vestiges here. They updated links seem to point to the correct issues and PRs in `react-tabs`s new home at `/reactjs/`.

:)