### PR TITLE
change ReactDOM.render to render

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import { Tab, Tabs, TabList, TabPanel } from '../../src/index';
 import '../../style/react-tabs.css';
 
@@ -111,4 +111,4 @@ const App = () => {
   );
 };
 
-ReactDOM.render(<App />, document.getElementById('example'));
+render(<App />, document.getElementById('example'));

--- a/examples/conditional/app.js
+++ b/examples/conditional/app.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import { Tab, Tabs, TabList, TabPanel } from '../../src/index';
 import '../../style/react-tabs.css';
 
@@ -52,5 +52,5 @@ class App extends React.Component {
   }
 }
 
-ReactDOM.render(<App />, document.getElementById('example'));
+render(<App />, document.getElementById('example'));
 

--- a/examples/dyno/app.js
+++ b/examples/dyno/app.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import Modal from 'react-modal';
 import { Tab, Tabs, TabList, TabPanel } from '../../src/index';
 import '../../style/react-tabs.css';
@@ -93,4 +93,4 @@ class App extends React.Component {
   }
 }
 
-ReactDOM.render(<App />, document.getElementById('example'));
+render(<App />, document.getElementById('example'));

--- a/examples/focus/app.js
+++ b/examples/focus/app.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import { Tab, Tabs, TabList, TabPanel } from '../../src/index';
 import '../../style/react-tabs.css';
 
@@ -40,4 +40,4 @@ class App extends React.Component {
   }
 }
 
-ReactDOM.render(<App />, document.getElementById('example'));
+render(<App />, document.getElementById('example'));

--- a/examples/nested/app.js
+++ b/examples/nested/app.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import { Tab, Tabs, TabList, TabPanel } from '../../src/index';
 import '../../style/react-tabs.css';
 
@@ -83,5 +83,5 @@ const App = () => {
   );
 };
 
-ReactDOM.render(<App />, document.getElementById('example'));
+render(<App />, document.getElementById('example'));
 


### PR DESCRIPTION
Hello, I hope everything is well, I contributed a small change on the examples folder, changed ReactDOM.render to render, to to be consistent with the README on the front page that uses render also, hope this helps in a little way.