### PR TITLE
Reference the fact that styles are on by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,13 @@ class App extends Component {
 
 ## Styling
 
-react-tabs does not include any style loading by default. Default stylesheets are provided and can be included in your application if desired.
+react-tabs come with a set of default styles, which are on by default. If you don't want to include those styles, you can disable them using the following
+
+```js
+Tabs.setUseDefaultStyles(false);
+```
+
+If you want more control of how and when to import the default styles, you can follow the approach in the sections below
 
 ### Webpack
 


### PR DESCRIPTION
Dist styles have been on by default for some time, and the option to opt out of
them has been added in #25 , but the README wasn't updated.

In order to not confuse users by not being truthful in the README, this PR updates it