### PR TITLE
Added nested Tablist Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "prettier": "^1.2.2",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
+    "react-children-utilities": "^0.1.10",
     "react-dom": "^15.0.0",
     "react-modal": "^1.3.0",
     "react-test-renderer": "^15.5.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "prettier": "^1.2.2",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
-    "react-children-utilities": "^0.1.10",
     "react-dom": "^15.0.0",
     "react-modal": "^1.3.0",
     "react-test-renderer": "^15.5.4",
@@ -79,7 +78,8 @@
   },
   "dependencies": {
     "classnames": "^2.2.0",
-    "prop-types": "^15.5.0"
+    "prop-types": "^15.5.0",
+    "react-children-utilities": "^0.1.10"
   },
   "jest": {
     "roots": [

--- a/src/components/UncontrolledTabs.js
+++ b/src/components/UncontrolledTabs.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { cloneElement, Component } from 'react';
+import Children from 'react-children-utilities';
 import cx from 'classnames';
 import uuid from '../helpers/uuid';
 import { childrenPropType } from '../helpers/propTypes';
@@ -132,7 +133,7 @@ export default class UncontrolledTabs extends Component {
     }
 
     // Map children to dynamically setup refs
-    return React.Children.map(children, child => {
+    return Children.deepMap(children, child => {
       // null happens when conditionally rendering TabPanel/Tab
       // see https://github.com/reactjs/react-tabs/issues/37
       if (child === null) {
@@ -157,7 +158,7 @@ export default class UncontrolledTabs extends Component {
         }
 
         result = cloneElement(child, {
-          children: React.Children.map(child.props.children, tab => {
+          children: Children.deepMap(child.props.children, tab => {
             // null happens when conditionally rendering TabPanel/Tab
             // see https://github.com/reactjs/react-tabs/issues/37
             if (tab === null) {

--- a/src/helpers/count.js
+++ b/src/helpers/count.js
@@ -1,14 +1,18 @@
 import React from 'react';
+import Children from 'react-children-utilities';
 import TabList from '../components/TabList';
 import Tab from '../components/Tab';
 import TabPanel from '../components/TabPanel';
 
 export function getTabsCount(children) {
-  const tabLists = React.Children.toArray(children).filter(x => x.type === TabList);
+  let tabList;
+  Children.deepForEach(children, c => {
+    if (!tabList && c.type === TabList) tabList = c;
+  });
 
-  if (tabLists[0] && tabLists[0].props.children) {
+  if (tabList && tabList.props.children) {
     return React.Children.count(
-      React.Children.toArray(tabLists[0].props.children).filter(x => x.type === Tab),
+      React.Children.toArray(tabList.props.children).filter(x => x.type === Tab),
     );
   }
 

--- a/src/helpers/propTypes.js
+++ b/src/helpers/propTypes.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Children from 'react-children-utilities';
 import Tab from '../components/Tab';
 import TabList from '../components/TabList';
 import TabPanel from '../components/TabPanel';
@@ -9,7 +10,7 @@ export function childrenPropType(props, propName, componentName) {
   let panelsCount = 0;
   const children = props[propName];
 
-  React.Children.forEach(children, child => {
+  Children.deepForEach(children, child => {
     // null happens when conditionally rendering TabPanel/Tab
     // see https://github.com/reactjs/react-tabs/issues/37
     if (child === null) {
@@ -30,10 +31,12 @@ export function childrenPropType(props, propName, componentName) {
       });
     } else if (child.type === TabPanel) {
       panelsCount++;
+      /*
     } else {
-      error = new Error(
-        `Expected 'TabList' or 'TabPanel' but found '${child.type.displayName || child.type}' in \`${componentName}\``,
-      );
+    error = new Error(
+      `Expected 'TabList' or 'TabPanel' but found '${child.type.displayName || child.type}' in \`${componentName}\``,
+    );
+    */
     }
   });
 


### PR DESCRIPTION
You can now nest TabList as per #114

ie.

```
<Tabs>
  <div id="tabs-nav-wrapper">
    <button>Left</button>
    <div className="tabs-container">
      <TabList>...</TabList>
    </div>
    <button>Right</button>
  </div>
  {tabPanels}
</Tabs>
```

Few things
- As its recursive, it could be slow depending on the complexity of the nodes. (Should this be a switch, or should we define the tablist via refs or something?)
- I have removed a check within propTypes.js, as it no longer makes sense.
- As such, I think we should just call getTabsCount and getPanelsCount, as opposed to duplicating code.
- The 2nd filter in getTabsCount is now redundant, we could just count the tabs directly
- Haven't tested nested TabPanel (This could probably be added with minimal effort)
- react-children-utilities has a deepFind feature as opposed to using deepForEach, however it doesn't appear to search all nodes (due to a toArray)

Thoughts?