### PR TITLE
feat(tabs): verify click tabNode using *[role=tab]

### DIFF
--- a/src/components/UncontrolledTabs.js
+++ b/src/components/UncontrolledTabs.js
@@ -9,7 +9,7 @@ import { isTabList, isTabPanel, isTab } from '../helpers/elementTypes';
 
 // Determine if a node from event.target is a Tab element
 function isTabNode(node) {
-  return node.nodeName === 'LI' && node.getAttribute('role') === 'tab';
+  return node.getAttribute('role') === 'tab';
 }
 
 // Determine if a tab node is disabled


### PR DESCRIPTION
Implementing `react-tabs` with custom `TabList` + `Tab` components can be currently done using the corresponding `tabsRole` static property, and this is neat. However, the check within `isTabNode()` relies on the tagName being an `LI` element, and this has some limitations for cases where a custom `<TabList />` component's markup does not match the `ul > li` structure.
  