### PR TITLE
fix(tabs): click wrapper container bubbles up and getAttribute() throws

### DIFF
--- a/src/components/UncontrolledTabs.js
+++ b/src/components/UncontrolledTabs.js
@@ -9,7 +9,7 @@ import { isTabList, isTabPanel, isTab } from '../helpers/elementTypes';
 
 // Determine if a node from event.target is a Tab element
 function isTabNode(node) {
-  return node.getAttribute('role') === 'tab';
+  return 'getAttribute' in node && node.getAttribute('role') === 'tab';
 }
 
 // Determine if a tab node is disabled


### PR DESCRIPTION
The last commit removed the use of `nodeName` within the check of `isTabNode(node)`, but the event can potentially bubble up all the way to the `DocumentElement` whose interface has no `getAttribute()` method.