### PR TITLE
Add prop to make BEM optional

### DIFF
--- a/src/components/Tab.js
+++ b/src/components/Tab.js
@@ -23,6 +23,7 @@ export default class Tab extends Component {
     disabledClassName: PropTypes.string,
     focus: PropTypes.bool, // private
     id: PropTypes.string, // private
+    noBEM: PropTypes.bool,
     panelId: PropTypes.string, // private
     selected: PropTypes.bool, // private
     selectedClassName: PropTypes.string,
@@ -51,6 +52,7 @@ export default class Tab extends Component {
       disabledClassName,
       focus, // unused
       id,
+      noBEM,
       panelId,
       selected,
       selectedClassName,
@@ -62,7 +64,8 @@ export default class Tab extends Component {
     return (
       <li
         {...attributes}
-        className={cx(className, {
+        className={cx({
+          [className]: noBEM ? !selected && !disabled : true,
           [selectedClassName]: selected,
           [disabledClassName]: disabled,
         })}

--- a/src/components/TabPanel.js
+++ b/src/components/TabPanel.js
@@ -16,6 +16,7 @@ export default class TabPanel extends Component {
     className: PropTypes.oneOfType([PropTypes.string, PropTypes.array, PropTypes.object]),
     forceRender: PropTypes.bool,
     id: PropTypes.string, // private
+    noBEM: PropTypes.bool,
     selected: PropTypes.bool, // private
     selectedClassName: PropTypes.string,
     tabId: PropTypes.string, // private
@@ -27,6 +28,7 @@ export default class TabPanel extends Component {
       className,
       forceRender,
       id,
+      noBEM,
       selected,
       selectedClassName,
       tabId,
@@ -36,7 +38,8 @@ export default class TabPanel extends Component {
     return (
       <div
         {...attributes}
-        className={cx(className, {
+        className={cx({
+          [className]: noBEM ? !selected : true,
           [selectedClassName]: selected,
         })}
         role="tabpanel"

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -20,6 +20,7 @@ export default class Tabs extends Component {
     disabledTabClassName: PropTypes.string,
     domRef: PropTypes.func,
     forceRenderTabPanel: PropTypes.bool,
+    noBEM: PropTypes.bool,
     onSelect: onSelectPropType,
     selectedIndex: selectedIndexPropType,
     selectedTabClassName: PropTypes.string,

--- a/src/components/UncontrolledTabs.js
+++ b/src/components/UncontrolledTabs.js
@@ -44,6 +44,7 @@ export default class UncontrolledTabs extends Component {
     domRef: PropTypes.func,
     focus: PropTypes.bool,
     forceRenderTabPanel: PropTypes.bool,
+    noBEM: PropTypes.bool,
     onSelect: PropTypes.func.isRequired,
     selectedIndex: PropTypes.number.isRequired,
     selectedTabClassName: PropTypes.string,
@@ -122,6 +123,7 @@ export default class UncontrolledTabs extends Component {
       disabledTabClassName,
       focus,
       forceRenderTabPanel,
+      noBEM,
       selectedIndex,
       selectedTabClassName,
       selectedTabPanelClassName,
@@ -174,6 +176,7 @@ export default class UncontrolledTabs extends Component {
 
             if (selectedTabClassName) props.selectedClassName = selectedTabClassName;
             if (disabledTabClassName) props.disabledClassName = disabledTabClassName;
+            if (noBEM) props.noBEM = noBEM;
 
             listIndex++;
 
@@ -286,6 +289,7 @@ export default class UncontrolledTabs extends Component {
       domRef,
       focus, // unused
       forceRenderTabPanel, // unused
+      noBEM, // unused
       onSelect, // unused
       selectedIndex, // unused
       selectedTabClassName, // unused


### PR DESCRIPTION
Hi folks,

We have a use case where we use atomic classes to define our styles. In the rest of our codebase, we have a granular way of overwriting props. When we need to use className as a string (such as when interfacing with react-tabs), we want to completely replace the base class, in order to overwrite styles properly.

For example, consider this (using `<div>` to simplify):
```js
// Common: display: inline-block and padding: 3; "dib pa3"

// idle
<div className="dib pa3 color-white"/>

// selected
<div className="dib pa3 color-blue"/>

// disabled
<div className="dib pa3 color-gray"/>
```

Current behaviour only allows this:
```js
// base className
<div className="dib pa3 color-white"/>

// selected
<div className="dib pa3 color-white color-blue"/>

// disabled
<div className="dib pa3 color-white color-gray"/>
```

**In other words:**
The current setup of react-tabs assumes a BEM style of classes where you have a base class and augment it depending on the state. This is fine because you can take care of CSS precedence with three BEM classes. With atomic/functional classes (and I am sure other use cases), this is not necessarily the case. _This PR enables disabling automatic BEM behaviour._

**Design notes:**
I called it `noBEM` to show that the BEM behaviour is not specified. It is up to the caller to make sure that the base class is repeated in the selected and disabled classes, if needed. It could be called `noAutoBEM` `disableAutoBEM`, or anything you deem appropriate.

I also chose this prop to be opt-in, so as not to break current behaviour. Apps probably rely on the automatic BEM style already, and I don't want to force a semver major bump.

There is also an _alternative design_, where instead of `noBEM`, we introduce an optional `idleClassName`, which is true on `!disabled && !selected`. This may be more general. I can do that if you think it fits your plans for the library better.

I hope I'm not missing anything, but I could not find a `Contributing.md` or equivalent. If you have any changes to suggest (tests, naming things), I'd be happy to work on them :)