### PR TITLE
To avoid the babel "'this' is not allowed before super()" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ This mode also enforces you to set a handler for `onSelect`. `defaultIndex` does
 ```js
 class App extends Component {
   constructor() {
+    super();
     this.state = { tabIndex: 0 };
   }
   render() {


### PR DESCRIPTION
If you build with babel/webkit (which create-react-app does), this example gives the error:

    'this' is not allowed before super()

Adding `super();` in the constructor allows it to build properly without error.

  