### PR TITLE
Fix unable to serve example website in node v.6.10.0

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ if (!isDev) {
         },
       },
       sourceMap: false,
-    }),
+    })
 );
 }
 


### PR DESCRIPTION
I tried run `npm run start` but there's an error as following
```
.../react-tabs\webpack.config.js:40
);
^
SyntaxError: Unexpected token )
```

after removing trailing comma for parameters of ` plugins.push` function, it works fine. 
I don't know if this error only occur in node version 6.10.0