### PR TITLE
Add support for home and end key on tab list

### DIFF
--- a/src/components/UncontrolledTabs.js
+++ b/src/components/UncontrolledTabs.js
@@ -107,6 +107,32 @@ export default class UncontrolledTabs extends Component {
     return index;
   }
 
+  getFirstTab() {
+    const count = this.getTabsCount();
+
+    // Look for non disabled tab from the first tab
+    for (let i = 0; i < count; i++) {
+      if (!isTabDisabled(this.getTab(i))) {
+        return i;
+      }
+    }
+
+    return null;
+  }
+
+  getLastTab() {
+    let i = this.getTabsCount();
+
+    // Look for non disabled tab from the last tab
+    while (i--) {
+      if (!isTabDisabled(this.getTab(i))) {
+        return i;
+      }
+    }
+
+    return null;
+  }
+
   getTabsCount() {
     return getTabsCount(this.props.children);
   }
@@ -226,6 +252,16 @@ export default class UncontrolledTabs extends Component {
       } else if (e.keyCode === 39 || e.keyCode === 40) {
         // Select next tab to the right
         index = this.getNextTab(index);
+        preventDefault = true;
+        useSelectedIndex = true;
+      } else if (e.keyCode === 35) {
+        // Select last tab (End key)
+        index = this.getLastTab();
+        preventDefault = true;
+        useSelectedIndex = true;
+      } else if (e.keyCode === 36) {
+        // Select first tab (Home key)
+        index = this.getFirstTab();
         preventDefault = true;
         useSelectedIndex = true;
       }


### PR DESCRIPTION
According to [WAI-ARIA Authoring Practices](https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/#tabpanel), we can navigate the tab list with `Home` and `End` key. Even though it's optional, It'd be nice if react-tabs supports it.