### PR TITLE
Issue 301 fix - Adding in the ability to add to classNames, instead of replacing them.

### DIFF
--- a/src/components/TabPanel.js
+++ b/src/components/TabPanel.js
@@ -40,9 +40,12 @@ export default class TabPanel extends Component {
     return (
       <div
         {...attributes}
-        className={cx(className, {
-          [selectedClassName]: selected,
-        })}
+        className={`
+          ${cx(DEFAULT_CLASS, {
+            [selectedClassName]: selected,
+          })} 
+          ${className}
+        `}
         role="tabpanel"
         id={id}
         aria-labelledby={tabId}

--- a/src/components/__tests__/__snapshots__/TabList-test.js.snap
+++ b/src/components/__tests__/__snapshots__/TabList-test.js.snap
@@ -43,7 +43,10 @@ exports[`<TabList /> should allow for higher order components 1`] = `
   </ul>
   <div
     aria-labelledby="react-tabs-12"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-13"
     role="tabpanel"
   >
@@ -51,7 +54,10 @@ exports[`<TabList /> should allow for higher order components 1`] = `
   </div>
   <div
     aria-labelledby="react-tabs-14"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-15"
     role="tabpanel"
   />
@@ -94,7 +100,10 @@ exports[`<TabList /> should display the custom classnames for selected and disab
   </ul>
   <div
     aria-labelledby="react-tabs-8"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-9"
     role="tabpanel"
   >
@@ -102,7 +111,10 @@ exports[`<TabList /> should display the custom classnames for selected and disab
   </div>
   <div
     aria-labelledby="react-tabs-10"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-11"
     role="tabpanel"
   />
@@ -145,7 +157,10 @@ exports[`<TabList /> should display the custom classnames for selected and disab
   </ul>
   <div
     aria-labelledby="react-tabs-4"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-5"
     role="tabpanel"
   >
@@ -153,7 +168,10 @@ exports[`<TabList /> should display the custom classnames for selected and disab
   </div>
   <div
     aria-labelledby="react-tabs-6"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-7"
     role="tabpanel"
   />
@@ -218,7 +236,10 @@ exports[`<TabList /> should retain the default classnames for active and disable
   </ul>
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   >
@@ -226,7 +247,10 @@ exports[`<TabList /> should retain the default classnames for active and disable
   </div>
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   />

--- a/src/components/__tests__/__snapshots__/TabPanel-test.js.snap
+++ b/src/components/__tests__/__snapshots__/TabPanel-test.js.snap
@@ -2,35 +2,50 @@
 
 exports[`<TabPanel /> should accept className 1`] = `
 <div
-  className="foobar"
+  className="
+          react-tabs__tab-panel 
+          foobar
+        "
   role="tabpanel"
 />
 `;
 
 exports[`<TabPanel /> should allow for higher-order components 1`] = `
 <div
-  className="react-tabs__tab-panel"
+  className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
   role="tabpanel"
 />
 `;
 
 exports[`<TabPanel /> should have sane defaults 1`] = `
 <div
-  className="react-tabs__tab-panel"
+  className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
   role="tabpanel"
 />
 `;
 
 exports[`<TabPanel /> should not allow overriding all default properties 1`] = `
 <div
-  className="react-tabs__tab-panel"
+  className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
   role="tabpanel"
 />
 `;
 
 exports[`<TabPanel /> should pass through custom properties 1`] = `
 <div
-  className="react-tabs__tab-panel"
+  className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
   data-tooltip="Tooltip contents"
   role="tabpanel"
 />
@@ -38,7 +53,10 @@ exports[`<TabPanel /> should pass through custom properties 1`] = `
 
 exports[`<TabPanel /> should render when forced 1`] = `
 <div
-  className="react-tabs__tab-panel"
+  className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
   role="tabpanel"
 >
   Hola
@@ -47,7 +65,10 @@ exports[`<TabPanel /> should render when forced 1`] = `
 
 exports[`<TabPanel /> should render when selected 1`] = `
 <div
-  className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+  className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
   role="tabpanel"
 >
   Hola
@@ -57,7 +78,10 @@ exports[`<TabPanel /> should render when selected 1`] = `
 exports[`<TabPanel /> should support being selected 1`] = `
 <div
   aria-labelledby="1234"
-  className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+  className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
   id="abcd"
   role="tabpanel"
 >
@@ -68,7 +92,10 @@ exports[`<TabPanel /> should support being selected 1`] = `
 exports[`<TabPanel /> should support being selected with custom class name 1`] = `
 <div
   aria-labelledby="1234"
-  className="react-tabs__tab-panel selected"
+  className="
+          react-tabs__tab-panel selected 
+          react-tabs__tab-panel
+        "
   id="abcd"
   role="tabpanel"
 >

--- a/src/components/__tests__/__snapshots__/Tabs-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Tabs-test.js.snap
@@ -62,7 +62,10 @@ exports[`<Tabs /> child props should reset ids correctly 1`] = `
   </ul>
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   >
@@ -70,19 +73,28 @@ exports[`<Tabs /> child props should reset ids correctly 1`] = `
   </div>
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-4"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-5"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-6"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-7"
     role="tabpanel"
   />
@@ -151,7 +163,10 @@ exports[`<Tabs /> child props should reset ids correctly 2`] = `
   </ul>
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   >
@@ -159,19 +174,28 @@ exports[`<Tabs /> child props should reset ids correctly 2`] = `
   </div>
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-4"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-5"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-6"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-7"
     role="tabpanel"
   />
@@ -240,7 +264,10 @@ exports[`<Tabs /> performance should render all tabs if forceRenderTabPanel is t
   </ul>
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   >
@@ -248,7 +275,10 @@ exports[`<Tabs /> performance should render all tabs if forceRenderTabPanel is t
   </div>
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   >
@@ -256,7 +286,10 @@ exports[`<Tabs /> performance should render all tabs if forceRenderTabPanel is t
   </div>
   <div
     aria-labelledby="react-tabs-4"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-5"
     role="tabpanel"
   >
@@ -264,7 +297,10 @@ exports[`<Tabs /> performance should render all tabs if forceRenderTabPanel is t
   </div>
   <div
     aria-labelledby="react-tabs-6"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-7"
     role="tabpanel"
   >
@@ -335,7 +371,10 @@ exports[`<Tabs /> props should accept className 1`] = `
   </ul>
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   >
@@ -343,19 +382,28 @@ exports[`<Tabs /> props should accept className 1`] = `
   </div>
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-4"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-5"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-6"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-7"
     role="tabpanel"
   />
@@ -424,7 +472,10 @@ exports[`<Tabs /> props should have sane defaults 1`] = `
   </ul>
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   >
@@ -432,19 +483,28 @@ exports[`<Tabs /> props should have sane defaults 1`] = `
   </div>
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-4"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-5"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-6"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-7"
     role="tabpanel"
   />
@@ -513,25 +573,37 @@ exports[`<Tabs /> props should honor negative defaultIndex prop 1`] = `
   </ul>
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-4"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-5"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-6"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-7"
     role="tabpanel"
   />
@@ -600,13 +672,19 @@ exports[`<Tabs /> props should honor positive defaultIndex prop 1`] = `
   </ul>
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   >
@@ -614,13 +692,19 @@ exports[`<Tabs /> props should honor positive defaultIndex prop 1`] = `
   </div>
   <div
     aria-labelledby="react-tabs-4"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-5"
     role="tabpanel"
   />
   <div
     aria-labelledby="react-tabs-6"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-7"
     role="tabpanel"
   />
@@ -663,7 +747,10 @@ exports[`<Tabs /> should allow for higher order components 1`] = `
   </ul>
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   >
@@ -671,7 +758,10 @@ exports[`<Tabs /> should allow for higher order components 1`] = `
   </div>
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   />
@@ -718,7 +808,10 @@ exports[`<Tabs /> should allow string children 1`] = `
   </ul>
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   >
@@ -726,7 +819,10 @@ exports[`<Tabs /> should allow string children 1`] = `
   </div>
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   />
@@ -806,13 +902,19 @@ exports[`<Tabs /> validation should allow other DOM nodes 1`] = `
   >
     <div
       aria-labelledby="react-tabs-0"
-      className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+      className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
       id="react-tabs-1"
       role="tabpanel"
     />
     <div
       aria-labelledby="react-tabs-2"
-      className="react-tabs__tab-panel"
+      className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
       id="react-tabs-3"
       role="tabpanel"
     />
@@ -829,7 +931,10 @@ exports[`<Tabs /> validation should allow random order for elements 1`] = `
 >
   <div
     aria-labelledby="react-tabs-0"
-    className="react-tabs__tab-panel react-tabs__tab-panel--selected"
+    className="
+          react-tabs__tab-panel react-tabs__tab-panel--selected 
+          react-tabs__tab-panel
+        "
     id="react-tabs-1"
     role="tabpanel"
   >
@@ -864,7 +969,10 @@ exports[`<Tabs /> validation should allow random order for elements 1`] = `
   </ul>
   <div
     aria-labelledby="react-tabs-2"
-    className="react-tabs__tab-panel"
+    className="
+          react-tabs__tab-panel 
+          react-tabs__tab-panel
+        "
     id="react-tabs-3"
     role="tabpanel"
   >


### PR DESCRIPTION
Adding in the ability to add to classNames, instead of replacing them, which prevents padding being pulled through to un-active TabPanels.

Relates to issue 301: https://github.com/reactjs/react-tabs/issues/301