### PR TITLE
Fix two warnings in the examples

### DIFF
--- a/examples/src/components/ExampleItem.js
+++ b/examples/src/components/ExampleItem.js
@@ -17,7 +17,7 @@ export default class ExampleItem extends Component {
     });
   }
 
-  handleEditSourceClick = () => {
+  handleEditSourceChange = () => {
     this.setState({
       editorOpen: !this.state.editorOpen,
     });
@@ -46,7 +46,7 @@ export default class ExampleItem extends Component {
               id={formId}
               name={formId}
               checked={editorOpen}
-              onClick={this.handleEditSourceClick}
+              onChange={this.handleEditSourceChange}
             />
             View source
           </label>

--- a/examples/src/components/examples/Avengers.js
+++ b/examples/src/components/examples/Avengers.js
@@ -70,13 +70,13 @@ const code = `class Component extends React.Component {
       const { img, color: backgroundColor, text: color, desc } = this.characters[name];
 
       tabs.push(
-        <Tab style={{ backgroundColor }} className="avengers-tab">
+        <Tab style={{ backgroundColor }} className="avengers-tab" key={name}>
           <img src={img} alt={name} height="32" width="32" />
         </Tab>
       );
 
       tabPanels.push(
-        <TabPanel style={{ backgroundColor, color }} className="avengers-tab-panel">
+        <TabPanel style={{ backgroundColor, color }} className="avengers-tab-panel" key={name}>
           {desc}
         </TabPanel>
       );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26581738/66708184-b450c380-ed4c-11e9-8bdb-a1d7233ef187.png)

- Use onChange instead of onClick for checkbox in examples
- Add missing key props in two lists in examples