### PR TITLE
Add environment prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ Provide a custom class name for disabled tabs.
 
 Register a callback that will receive the underlying DOM node for every mount. It will also receive null on unmount.
 
+#### environment: `Window`
+
+> default: `window`
+
+If you're rendering `react-tabs` within a different `window` context than the default one; for example, an iframe.
+
 #### forceRenderTabPanel: `boolean`
 
 > default: `false`

--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ Register a callback that will receive the underlying DOM node for every mount. I
 
 #### environment: `Window`
 
-> default: `window`
-
 If you're rendering `react-tabs` within a different `window` context than the default one; for example, an iframe.
 
 #### forceRenderTabPanel: `boolean`

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -17,6 +17,7 @@ export default class Tabs extends Component {
     forceRenderTabPanel: false,
     selectedIndex: null,
     defaultIndex: null,
+    environment: window,
   };
 
   static propTypes = {
@@ -36,6 +37,7 @@ export default class Tabs extends Component {
     selectedIndex: selectedIndexPropType,
     selectedTabClassName: PropTypes.string,
     selectedTabPanelClassName: PropTypes.string,
+    environment: PropTypes.object,
   };
 
   constructor(props) {

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -17,7 +17,7 @@ export default class Tabs extends Component {
     forceRenderTabPanel: false,
     selectedIndex: null,
     defaultIndex: null,
-    environment: window,
+    environment: null,
   };
 
   static propTypes = {

--- a/src/components/UncontrolledTabs.js
+++ b/src/components/UncontrolledTabs.js
@@ -24,11 +24,14 @@ function isTabDisabled(node) {
 let canUseActiveElement;
 
 function determineCanUseActiveElement(environment) {
+  const env =
+    environment || (typeof window !== 'undefined' ? window : undefined);
+
   try {
     canUseActiveElement = !!(
-      typeof environment !== 'undefined' &&
-      environment.document &&
-      environment.document.activeElement
+      typeof env !== 'undefined' &&
+      env.document &&
+      env.document.activeElement
     );
   } catch (e) {
     // Work around for IE bug when accessing document.activeElement in an iframe
@@ -202,9 +205,12 @@ export default class UncontrolledTabs extends Component {
         if (canUseActiveElement) {
           wasTabFocused = React.Children.toArray(child.props.children)
             .filter(isTab)
-            .some(
-              (tab, i) => environment.document.activeElement === this.getTab(i),
-            );
+            .some((tab, i) => {
+              const env =
+                environment ||
+                (typeof window !== 'undefined' ? window : undefined);
+              return env && env.document.activeElement === this.getTab(i);
+            });
         }
 
         result = cloneElement(child, {

--- a/src/components/UncontrolledTabs.js
+++ b/src/components/UncontrolledTabs.js
@@ -361,6 +361,7 @@ export default class UncontrolledTabs extends Component {
       selectedIndex, // unused
       selectedTabClassName, // unused
       selectedTabPanelClassName, // unused
+      environment, // unused
       ...attributes
     } = this.props;
 

--- a/src/components/__tests__/Tabs-node-test.js
+++ b/src/components/__tests__/Tabs-node-test.js
@@ -1,6 +1,3 @@
-/**
- * @jest-environment node
- */
 /* eslint-env jest */
 import React from 'react';
 import Tab from '../Tab';

--- a/src/components/__tests__/Tabs-node-test.js
+++ b/src/components/__tests__/Tabs-node-test.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 /* eslint-env jest */
 import React from 'react';
 import Tab from '../Tab';


### PR DESCRIPTION
I've ran into a use case where the focus between tabs wasn't properly handled while navigating using the arrow keys due to  having `react-tabs` rendered on an `iframe`.

Inspired by [`downshift`](https://github.com/downshift-js/downshift#environment), this PR adds an `environment` prop to allow users to specify a different `window` if they need to.