### PR TITLE
adds untracked IDE files/folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ lib/
 dist/
 esm/
 yarn-error.log
+*.DS_Store
+.idea
+*.vscode/
+.project
+.classpath
+*.sublime-workspace


### PR DESCRIPTION
There are some files/folders missing from the .gitignore. We can prevent committing untracked files by including them in the .gitignore.