### PR TITLE
Update README to use local path to browser stack logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://reactcommunity.org/react-tabs/
 > Supports React 16.3.0 or newer
 
 <ins><blockquote class="rich-diff-level-zero"> <p class="rich-diff-level-one">react-tabs was tested on real mobile devices and browsers with<br>
-  <img src="https://reactcommunity.org/react-tabs/2e0bf9a22057e69b716b45a3d5bffbe7.svg" height="50" alt="Browserstack">
+  <img src="./examples/src/images/Browserstack-logo.svg" height="50" alt="Browserstack">
 
 </p> </blockquote></ins>
 


### PR DESCRIPTION
No idea when/how this broke, or if it works on a website somewhere but this at least fixes it in GitHub 👍🏻 