### PR TITLE
Improve output code size and do not package tests

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -8,7 +8,28 @@ const modules = output == null ? false : output;
 const targets = env === 'test' ? { node: 'current' } : undefined;
 
 const options = {
-  presets: [['@babel/env', { loose: true, modules, targets }], '@babel/react'],
+  assumptions: {
+    ignoreToPrimitiveHint: true,
+    iterableIsArray: true,
+    mutableTemplateObject: true,
+    noNewArrows: true,
+    objectRestNoSymbols: true,
+    setComputedProperties: true,
+    setSpreadProperties: true,
+  },
+  presets: [
+    [
+      '@babel/env',
+      {
+        loose: true,
+        modules,
+        targets,
+        corejs: '3',
+        useBuiltIns: 'entry',
+      },
+    ],
+    ['@babel/react', { useBuiltIns: true }],
+  ],
   plugins: [],
 };
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "esm",
     "lib",
     "style",
-    "src"
+    "src/*.js",
+    "src/components/*.js",
+    "src/helpers/*.js"
   ],
   "homepage": "https://github.com/reactjs/react-tabs",
   "keywords": [


### PR DESCRIPTION
BREAKING CHANGE: The package now does use `Object.assign` directly instead of babel helpers. In older browsers you might need to pollyfill these. `react` itself has the same dependency.