### PR TITLE
Concatenar classes css com props

### DIFF
--- a/src/components/Tab.js
+++ b/src/components/Tab.js
@@ -61,7 +61,7 @@ const Tab = (props) => {
   return (
     <li
       {...attributes}
-      className={cx(className, {
+      className={cx(DEFAULT_CLASS, className, { // Concatena a classe padrão com a classe existente
         [selectedClassName]: selected,
         [disabledClassName]: disabled,
       })}


### PR DESCRIPTION
className={cx(DEFAULT_CLASS, className, { // Concatena a classe padrão com a classe existente
        [selectedClassName]: selected,
        [disabledClassName]: disabled,
      })}

Recomendação de alteração para concatenar classes sem perde o default