### PR TITLE
Update Tab.js

### DIFF
--- a/src/components/Tab.js
+++ b/src/components/Tab.js
@@ -65,10 +65,7 @@ const Tab = (props) => {
         [selectedClassName]: selected,
         [disabledClassName]: disabled,
       })}
-      ref={(node) => {
-        nodeRef.current = node;
-        if (tabRef) tabRef(node);
-      }}
+      ref={noderef}
       role="tab"
       id={`tab${id}`}
       aria-selected={selected ? 'true' : 'false'}


### PR DESCRIPTION
The current code uses the old-style ref callback ref={(node) => { nodeRef.current = node; }}, which is still functional but can be simplified using the useRef hook directly: