### PR TITLE
removing content in react-tabs.css

### DIFF
--- a/style/react-tabs.css
+++ b/style/react-tabs.css
@@ -36,7 +36,6 @@
 }
 
 .react-tabs__tab:focus:after {
-  content: '';
   position: absolute;
   height: 5px;
   left: -4px;


### PR DESCRIPTION
When selecting a tab in dark background creates another small overflow in the bottom of the tab because of the content added. I hope it will look better this way. Feel free to comment your thoughts.